### PR TITLE
Adding files: enriched cotensors, enriched tensor prod of cats, enriched op-cat

### DIFF
--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/Cotensors.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/Cotensors.lean
@@ -15,6 +15,7 @@ namespace SimplicialCategory
 variable [SimplicialCategory K]
 variable {K}
 
+-- In Enriched/Cotensors, this is Precotensor.coneNatTrans
 def coneNatTrans {A : SSet} {AX X : K} (Y : K) (cone : A ⟶ sHom AX X) :
   -- The notation `A ⟶[SSet] sHom Y X` is ambiguous, could mean both `ihom` or the enriched hom...
   -- Here we mean `ihom` so we write that explicitly.
@@ -26,6 +27,7 @@ def coneNatTrans {A : SSet} {AX X : K} (Y : K) (cone : A ⟶ sHom AX X) :
 structure IsCotensor {A : SSet} {X : K} (AX : K) (cone : A ⟶ sHom AX X) where
   uniq : ∀ (Y : K), (IsIso (coneNatTrans Y cone))
 
+-- structure Cotensor
 structure CotensorCone (A : SSet) (X : K) where
   /-- The object -/
   obj : K
@@ -47,6 +49,7 @@ def getCotensorCone (A : SSet) (X : K) [HasCotensor A X] : CotensorCone A X :=
   Classical.choice <| HasCotensor.exists_cotensor
 
 variable (K) in
+-- DC: CotensoredCategory
 /-- `K` has simplicial cotensors when cotensors with any simplicial set exist. -/
 class HasCotensors : Prop where
   /-- All `A : SSet` and `X : K` have a cotensor. -/
@@ -83,13 +86,16 @@ def cotensor.iso.underlying (A : SSet) (X : K) [HasCotensor A X] (Y : K) :
       (cotensor.iso A X Y)).toEquiv.trans
         (SimplicialCategory.homEquiv' A (sHom Y X)).symm
 
+-- DC: postcompose
 def cotensorCovMap [HasCotensors K] (A : SSet) {X Y : K} (f : X ⟶ Y) : A ⋔ X ⟶ A ⋔ Y :=
   (cotensor.iso.underlying A Y (A ⋔ X)).symm
     ((cotensor.cone A X) ≫ (sHomWhiskerLeft (A ⋔ X) f))
 
+-- DC: EhomPrecompose
 def cotensorContraMap [HasCotensors K] {A B : SSet} (i : A ⟶ B) (X : K) : B ⋔ X ⟶ A ⋔ X :=
   (cotensor.iso.underlying A X (B ⋔ X)).symm (i ≫ (cotensor.cone B X))
 
+-- DC: post_pre_eq_pre_post
 theorem cotensor_bifunctoriality [HasCotensors K] {A B : SSet} (i : A ⟶ B) {X Y : K} (f : X ⟶ Y) :
     (cotensorCovMap B f) ≫ (cotensorContraMap i Y) =
     (cotensorContraMap i X) ≫ (cotensorCovMap A f) := by sorry

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/Cotensors.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/Cotensors.lean
@@ -15,7 +15,7 @@ namespace SimplicialCategory
 variable [SimplicialCategory K]
 variable {K}
 
--- In Enriched/Cotensors, this is Precotensor.coneNatTrans
+-- DC: In Enriched/Cotensors, this is Precotensor.coneNatTrans
 def coneNatTrans {A : SSet} {AX X : K} (Y : K) (cone : A ⟶ sHom AX X) :
   -- The notation `A ⟶[SSet] sHom Y X` is ambiguous, could mean both `ihom` or the enriched hom...
   -- Here we mean `ihom` so we write that explicitly.
@@ -27,7 +27,7 @@ def coneNatTrans {A : SSet} {AX X : K} (Y : K) (cone : A ⟶ sHom AX X) :
 structure IsCotensor {A : SSet} {X : K} (AX : K) (cone : A ⟶ sHom AX X) where
   uniq : ∀ (Y : K), (IsIso (coneNatTrans Y cone))
 
--- structure Cotensor
+-- DC: structure Cotensor
 structure CotensorCone (A : SSet) (X : K) where
   /-- The object -/
   obj : K

--- a/InfinityCosmos/ForMathlib/CategoryTheory/Enriched/Cotensors.lean
+++ b/InfinityCosmos/ForMathlib/CategoryTheory/Enriched/Cotensors.lean
@@ -8,20 +8,17 @@ open CategoryTheory MonoidalCategory MonoidalClosed BraidedCategory SymmetricCat
 
 open scoped MonoidalClosed
 
-/- My own namesapce for experimenting with enriched categories -/
 namespace CategoryTheory
 
 namespace Enriched
 
 --TODO: This is intended to be notation, but I'm having trouble with getting that to work
 -- so for now, this is a reducible definition
-@[reducible]
-def Ihom (V : Type u) [Category.{u₁, u} V] [MonoidalCategory V] [MonoidalClosed V] (x y : V) : V :=
+abbrev Ihom (V : Type u) [Category.{u₁, u} V] [MonoidalCategory V] [MonoidalClosed V] (x y : V) : V :=
   (ihom x).obj y
 
 -- The variable V is explicit here since trying to make it implicit throws errors in practice
-@[reducible]
-def Ehom (V : Type u) [Category.{u₁, u} V] [MonoidalCategory V] [MonoidalClosed V]
+abbrev Ehom (V : Type u) [Category.{u₁, u} V] [MonoidalCategory V] [MonoidalClosed V]
     (C : Type v) [EnrichedCategory V C] (x y : C) : V :=
   @EnrichedCategory.Hom V _ _ _ _ x y
 
@@ -54,7 +51,7 @@ lemma Precotensor.coneNatTrans_braid_eq {v : V} {x : C} (vx : Precotensor v x) (
   apply (Iso.inv_comp_eq (β_ v (Ehom V C y vx.obj))).mpr
   exact vx.coneNatTrans_eq y
 
-/-- A Cotensor is a Precotensor such that coneNatTransInv is an inverse to coneNatTrans. -/
+/-- A `Cotensor` is a `Precotensor` such that `coneNatTransInv` is an inverse to `coneNatTrans`. -/
 structure Cotensor (v : V) (x : C) extends (Precotensor v x) where
   coneNatTransInv (y : C) :
     (Ihom V v (Ehom V C y x)) ⟶ (Ehom V C y obj)
@@ -74,12 +71,6 @@ instance {v : V} {x : C} {vx : Cotensor v x} {y : C} : IsIso (vx.coneNatTrans y)
     left := vx.NatTrans_NatTransInv_eq y
     right := vx.NatTransInv_NatTrans_eq y
   }⟩
-
-end Enriched
-
-end CategoryTheory
-
-open Enriched
 
 namespace Cotensor
 
@@ -189,8 +180,8 @@ def IhomPrecompose {x : C} {w v : V} (wx : Cotensor w x) (vx : Cotensor v x) :
     Ihom V w v ⟶ Ehom V C vx.obj wx.obj :=
   (ihom w).map vx.cone ≫ wx.coneNatTransInv vx.obj
 
-def EhomPrecompose {x : C} {w v : V} (wx : Cotensor w x) (vx : Cotensor v x)
-    : Ehom V V w v ⟶ Ehom V C vx.obj wx.obj := IhomPrecompose V _ _
+def EhomPrecompose {x : C} {w v : V} (wx : Cotensor w x) (vx : Cotensor v x) :
+    Ehom V V w v ⟶ Ehom V C vx.obj wx.obj := IhomPrecompose V _ _
 
 lemma IhomPrecompose_coneNatTrans_eq {x : C} {w v : V} (wx : Cotensor w x) (vx : Cotensor v x) :
     IhomPrecompose V wx vx ≫ wx.coneNatTrans _ = (ihom w).map vx.cone :=
@@ -314,11 +305,6 @@ theorem precompose_id_eq {x : C} {v : V} (vx : Cotensor v x) :
     Category.assoc]
   rw [uncurry_eq]
 
-  -- apply (Iso.inv_comp_eq _).mp
-  -- Moving selfEval up on the LHS
-  -- rw [whisker_exchange_assoc]
-  -- rw [← rightUnitor_inv_naturality_assoc]
-  -- Moving up selfEval on the RHS
   rw [← whisker_exchange_assoc]
   rw [← leftUnitor_inv_naturality_assoc]
   simp only [e_id_comp, Category.comp_id]
@@ -336,7 +322,7 @@ theorem precompose_id_eq {x : C} {v : V} (vx : Cotensor v x) :
   --
   rw [uncurry_curry]
 
-/-- Commutativity of postcomposition with precoposition -/
+/-- Naturality of postcomposition with precoposition -/
 theorem post_pre_eq_pre_post {x y : C} {w v : V} (wx : Cotensor w x) (wy : Cotensor w y)
     (vx : Cotensor v x) (vy : Cotensor v y) :
   (EhomPrecompose V wx vx ⊗ postcompose V wx wy) ≫ eComp V vx.obj wx.obj wy.obj =
@@ -485,3 +471,7 @@ def cotensor_bifunc [CotensoredCategory V C] : EnrichedFunctor V ((eOpposite V V
       (cotensor (unop V w) y))
 
 end Cotensor
+
+end Enriched
+
+end CategoryTheory

--- a/InfinityCosmos/ForMathlib/CategoryTheory/Enriched/Cotensors.lean
+++ b/InfinityCosmos/ForMathlib/CategoryTheory/Enriched/Cotensors.lean
@@ -1,0 +1,487 @@
+import InfinityCosmos.ForMathlib.CategoryTheory.Enriched.MonoidalProdCat
+import InfinityCosmos.ForMathlib.CategoryTheory.Enriched.Opposite
+import Mathlib.CategoryTheory.Closed.Enrichment
+
+universe u u₁ v w
+
+open CategoryTheory MonoidalCategory MonoidalClosed BraidedCategory SymmetricCategory
+
+open scoped MonoidalClosed
+
+/- My own namesapce for experimenting with enriched categories -/
+namespace CategoryTheory
+
+namespace Enriched
+
+--TODO: This is intended to be notation, but I'm having trouble with getting that to work
+-- so for now, this is a reducible definition
+@[reducible]
+def Ihom (V : Type u) [Category.{u₁, u} V] [MonoidalCategory V] [MonoidalClosed V] (x y : V) : V :=
+  (ihom x).obj y
+
+-- The variable V is explicit here since trying to make it implicit throws errors in practice
+@[reducible]
+def Ehom (V : Type u) [Category.{u₁, u} V] [MonoidalCategory V] [MonoidalClosed V]
+    (C : Type v) [EnrichedCategory V C] (x y : C) : V :=
+  @EnrichedCategory.Hom V _ _ _ _ x y
+
+def Ihom_Ehom_eq (V : Type u) [Category.{u₁, u} V] [MonoidalCategory V] [MonoidalClosed V]
+    (x y : V) : Ihom V x y = Ehom V V x y :=
+  rfl
+
+-- New stuff
+variable {V : Type u} [Category.{u₁, u} V] [MonoidalCategory V] [SymmetricCategory V]
+  [MonoidalClosed V]
+variable {C : Type v} [EnrichedCategory V C]
+
+/-- The structure of the cotensoring of `x : C` by `v : V` -/
+structure Precotensor (v : V) (x : C) where
+  obj : C
+  cone : v ⟶ (Ehom V C obj x)
+
+/-- The adjoint tranpose of precotensor_eval -/
+def Precotensor.coneNatTrans {v : V} {x : C} (vx : Precotensor v x) (y : C) :
+    (Ehom V C y vx.obj) ⟶ (Ihom V v (Ehom V C y x)) :=
+  curry ((β_ v (Ehom V C y vx.obj)).hom ≫ Ehom V C y vx.obj ◁ vx.cone ≫ eComp V y vx.obj x)
+
+lemma Precotensor.coneNatTrans_eq {v : V} {x : C} (vx : Precotensor v x) (y : C) :
+    uncurry (vx.coneNatTrans y) = (β_ _ _).hom ≫ _ ◁ vx.cone ≫ eComp V y vx.obj x :=
+  uncurry_curry _
+
+lemma Precotensor.coneNatTrans_braid_eq {v : V} {x : C} (vx : Precotensor v x) (y : C) :
+    (β_ _ _).hom ≫ uncurry (vx.coneNatTrans y) = _ ◁ vx.cone ≫ eComp V y vx.obj x := by
+  rw [braiding_swap_eq_inv_braiding]
+  apply (Iso.inv_comp_eq (β_ v (Ehom V C y vx.obj))).mpr
+  exact vx.coneNatTrans_eq y
+
+/-- A Cotensor is a Precotensor such that coneNatTransInv is an inverse to coneNatTrans. -/
+structure Cotensor (v : V) (x : C) extends (Precotensor v x) where
+  coneNatTransInv (y : C) :
+    (Ihom V v (Ehom V C y x)) ⟶ (Ehom V C y obj)
+  NatTransInv_NatTrans_eq (y : C) :
+    (coneNatTransInv y ≫ Precotensor.coneNatTrans toPrecotensor y = 𝟙 _)
+  NatTrans_NatTransInv_eq (y : C) :
+    (Precotensor.coneNatTrans toPrecotensor y ≫ coneNatTransInv y = 𝟙 _)
+
+instance {v : V} {x : C} {vx : Cotensor v x} {y : C} : IsIso (vx.coneNatTransInv y) where
+  out := ⟨vx.coneNatTrans y, {
+    left := vx.NatTransInv_NatTrans_eq y
+    right := vx.NatTrans_NatTransInv_eq y
+  }⟩
+
+instance {v : V} {x : C} {vx : Cotensor v x} {y : C} : IsIso (vx.coneNatTrans y) where
+  out := ⟨vx.coneNatTransInv y, {
+    left := vx.NatTrans_NatTransInv_eq y
+    right := vx.NatTransInv_NatTrans_eq y
+  }⟩
+
+end Enriched
+
+end CategoryTheory
+
+open Enriched
+
+namespace Cotensor
+
+variable (V : Type u) [Category.{u₁} V] [MonoidalCategory V] [SymmetricCategory V] [MonoidalClosed V]
+variable {C : Type v} [EnrichedCategory V C]
+
+-- Postcomposition and its coherences
+def postcompose {x y : C} {v : V} (vx : Cotensor v x) (vy : Cotensor v y) :
+    Ehom V C x y ⟶ Ehom V C vx.obj vy.obj :=
+  curry (vx.cone ▷ Ehom V C x y ≫ eComp V vx.obj x y) ≫ vy.coneNatTransInv vx.obj
+
+lemma postcompose_coneNatTrans_eq {x y : C} {v : V} (vx : Cotensor v x) (vy : Cotensor v y) :
+    postcompose V vx vy ≫ vy.coneNatTrans _ = curry (vx.cone ▷ _ ≫ eComp V _ _ _) :=
+  ((Category.assoc _ _ _).trans (whisker_eq _ (vy.NatTransInv_NatTrans_eq _))).trans (Category.comp_id _)
+
+lemma uncurry_postcompose_coneNatTrans_eq {x y : C} {v : V} (vx : Cotensor v x) (vy : Cotensor v y) :
+    uncurry (postcompose V vx vy ≫ vy.coneNatTrans _) = vx.cone ▷ _ ≫ eComp V _ _ _ := by
+  simp only [postcompose_coneNatTrans_eq, uncurry_curry]
+
+lemma postcompose_selfEval_comp_eq {x y : C} {v : V} (vx : Cotensor v x) (vy : Cotensor v y) :
+    (postcompose V vx vy ▷ _) ≫ (_ ◁ vy.cone) ≫ (eComp V vx.obj vy.obj y)
+      = (β_ _ v).hom ≫ (vx.cone ▷ _) ≫ (eComp V vx.obj x y) := by
+  rw [← vy.coneNatTrans_braid_eq, braiding_naturality_left_assoc]
+  apply (Iso.cancel_iso_hom_left _ _ _).mpr
+  apply curry_injective
+  rw [curry_natural_left, curry_uncurry]
+  exact postcompose_coneNatTrans_eq V vx vy
+
+-- Functorality of post-composition
+theorem postcompose_comp_eq {x y z : C} {v : V} (vx : Cotensor v x) (vy : Cotensor v y)
+    (vz : Cotensor v z) : eComp V x y z ≫ postcompose V vx vz =
+      (postcompose V vx vy ⊗ postcompose V vy vz) ≫ eComp V _ _ _ := by
+  -- Work the LHS
+  apply (cancel_mono (vz.coneNatTrans _)).mp
+  apply uncurry_injective
+  simp only [Category.assoc]
+  rw [uncurry_natural_left]
+  rw [uncurry_postcompose_coneNatTrans_eq]
+  -- This final exchange solves at the end
+  rw [whisker_exchange_assoc]
+
+  -- Work the RHS
+  simp only [tensorHom_def, uncurry_natural_left,
+    MonoidalCategory.whiskerLeft_comp, vz.coneNatTrans_eq, Category.assoc]
+  rw [braiding_naturality_right_assoc]
+  rw [braiding_naturality_right_assoc]
+  nth_rw 2 [← whisker_exchange_assoc]
+  simp only [braiding_tensor_right, Category.assoc]
+  rw [← associator_inv_naturality_middle_assoc]
+  rw [← associator_inv_naturality_right_assoc]
+  rw [e_assoc]
+  nth_rw 2 [← MonoidalCategory.whiskerLeft_comp_assoc]
+  nth_rw 2 [← MonoidalCategory.whiskerLeft_comp_assoc]
+  -- This invokes commutativity of post with selfEval
+  simp only [Category.assoc, postcompose_selfEval_comp_eq,
+    MonoidalCategory.whiskerLeft_comp]
+  -- Now we can use symmetry
+  rw [← MonoidalCategory.whiskerLeft_comp_assoc]
+  simp only [symmetry, MonoidalCategory.whiskerLeft_id, Category.id_comp]
+  -- Moving a morphism through a bunch of associators and braids >_>
+  rw [associator_inv_naturality_middle_assoc]
+  -- Annoying
+  rw [← comp_whiskerRight_assoc]
+  rw [braiding_naturality_right]
+  rw [comp_whiskerRight_assoc]
+  --
+  rw [← associator_naturality_middle_assoc]
+  --
+  rw [(e_assoc' V vx.obj vy.obj y z)]
+  --
+  nth_rw 3 [← comp_whiskerRight_assoc]
+  nth_rw 2 [← comp_whiskerRight_assoc]
+  simp only [postcompose_selfEval_comp_eq, comp_whiskerRight, Category.assoc]
+  -- Take out the symmetry
+  rw [← comp_whiskerRight_assoc]
+  simp only [symmetry, id_whiskerRight, Category.id_comp]
+  -- All posts are gone from the equation
+  rw [← associator_inv_naturality_left_assoc]
+  rw [e_assoc]
+
+theorem postcompose_id_eq {x : C} {v : V} (vx : Cotensor v x) :
+    eId V x ≫ postcompose V vx vx = eId V vx.obj := by
+  -- These lines are copied from the last proof - consider isolating!
+  apply (cancel_mono (vx.coneNatTrans _)).mp
+  apply uncurry_injective
+  simp only [Category.assoc]
+  rw [uncurry_natural_left]
+  rw [uncurry_postcompose_coneNatTrans_eq]
+  -- This is copied from the RHS part of the previous proof
+  simp only [uncurry_natural_left, MonoidalCategory.whiskerLeft_comp,
+    vx.coneNatTrans_eq, Category.assoc]
+  simp only [braiding_naturality_right_assoc, braiding_tensorUnit_right,
+    Category.assoc]
+  -- Braiding has been replaced by unitors
+  apply (Iso.inv_comp_eq _).mp
+  -- Moving selfEval up on the LHS
+  rw [whisker_exchange_assoc]
+  rw [← rightUnitor_inv_naturality_assoc]
+  -- Moving up selfEval on the RHS
+  rw [← whisker_exchange_assoc]
+  rw [← leftUnitor_inv_naturality_assoc]
+  -- Final step
+  rw [e_id_comp, e_comp_id]
+
+-- Precomposition and its coherences
+def IhomPrecompose {x : C} {w v : V} (wx : Cotensor w x) (vx : Cotensor v x) :
+    Ihom V w v ⟶ Ehom V C vx.obj wx.obj :=
+  (ihom w).map vx.cone ≫ wx.coneNatTransInv vx.obj
+
+def EhomPrecompose {x : C} {w v : V} (wx : Cotensor w x) (vx : Cotensor v x)
+    : Ehom V V w v ⟶ Ehom V C vx.obj wx.obj := IhomPrecompose V _ _
+
+lemma IhomPrecompose_coneNatTrans_eq {x : C} {w v : V} (wx : Cotensor w x) (vx : Cotensor v x) :
+    IhomPrecompose V wx vx ≫ wx.coneNatTrans _ = (ihom w).map vx.cone :=
+  ((Category.assoc _ _ _).trans (whisker_eq _ (wx.NatTransInv_NatTrans_eq _))).trans (Category.comp_id _)
+
+lemma EhomPrecompose_coneNatTrans_eq {x : C} {w v : V} (wx : Cotensor w x) (vx : Cotensor v x) :
+    EhomPrecompose V wx vx ≫ wx.coneNatTrans _ = (ihom w).map vx.cone :=
+  IhomPrecompose_coneNatTrans_eq V wx vx
+
+lemma IhomPrecompose_selfEval_comp_eq {x : C} {w v : V} (wx : Cotensor w x) (vx : Cotensor v x) :
+    (IhomPrecompose V wx vx) ▷ _ ≫ (_ ◁ wx.cone) ≫ eComp V _ _ _
+      = (β_ _ _).hom ≫ (ihom.ev w).app v ≫ vx.cone := by
+  rw [← ihom.ev_naturality]
+  rw [← braiding_naturality_left_assoc]
+  unfold IhomPrecompose
+  rw [MonoidalCategory.comp_whiskerRight_assoc]
+  apply whisker_eq
+  apply (cancel_epi ((wx.coneNatTrans _) ▷ w)).mp
+  rw [← comp_whiskerRight_assoc]
+  simp only [wx.NatTrans_NatTransInv_eq, id_whiskerRight, Category.id_comp]
+  rw [braiding_naturality_left_assoc]
+  rw [← uncurry_eq]
+  exact (Precotensor.coneNatTrans_braid_eq wx.toPrecotensor vx.obj).symm
+
+lemma EhomPrecompose_selfEval_comp_eq {x : C} {w v : V} (wx : Cotensor w x) (vx : Cotensor v x) :
+    (EhomPrecompose V wx vx) ▷ _ ≫ (_ ◁ wx.cone) ≫ eComp V _ _ _
+      = (β_ _ _).hom ≫ (ihom.ev w).app v ≫ vx.cone :=
+  IhomPrecompose_selfEval_comp_eq V wx vx
+
+-- Functoriality of precomposition
+theorem precompose_comp_eq {x : C} {u v w : V} (ux : Cotensor u x) (vx : Cotensor v x)
+    (wx : Cotensor w x) : eComp V u v w ≫ EhomPrecompose V ux wx =
+      (EhomPrecompose V ux vx ⊗ EhomPrecompose V vx wx) ≫ (β_ _ _).hom ≫ eComp V _ _ _ := by
+  apply (cancel_mono (ux.coneNatTrans _)).mp
+  simp only [Category.assoc]
+  rw [EhomPrecompose_coneNatTrans_eq]
+  apply uncurry_injective
+  simp only [uncurry_natural_left]
+  rw [ux.coneNatTrans_eq]
+  -- Moving comp to after selfEval
+  rw [braiding_naturality_right_assoc]
+  rw [← whisker_exchange_assoc]
+  -- Moving Precompose down to comp
+  simp only [tensorHom_def', MonoidalCategory.whiskerLeft_comp, Category.assoc]
+  -- Annoying move again
+  nth_rw 2 [← MonoidalCategory.whiskerLeft_comp_assoc]
+  rw [braiding_naturality_left]
+  rw [MonoidalCategory.whiskerLeft_comp_assoc]
+  --
+  rw [braiding_naturality_right_assoc]
+  simp only [braiding_tensor_right, whisker_assoc, tensor_whiskerLeft,
+    Category.assoc, Iso.inv_hom_id_assoc]
+  rw [e_assoc]
+  nth_rw 4 [← MonoidalCategory.whiskerLeft_comp_assoc]
+  nth_rw 3 [← MonoidalCategory.whiskerLeft_comp_assoc]
+  simp only [EhomPrecompose_selfEval_comp_eq, MonoidalCategory.whiskerLeft_comp,
+    Category.assoc]
+  nth_rw 2 [← MonoidalCategory.whiskerLeft_comp_assoc]
+  -- Another very bad
+  have t := symmetry u (Ehom V V u v)
+  have t' : (β_ (Ehom V V u v) u).hom = (β_ ((ihom u).obj v) u).hom := rfl
+  rw [t'] at t
+  rw [t]
+  --
+  simp only [MonoidalCategory.whiskerLeft_id, Category.id_comp]
+  -- The lemma again
+  rw [← MonoidalCategory.whiskerLeft_comp_assoc]
+  rw [braiding_naturality_right]
+  rw [MonoidalCategory.whiskerLeft_comp_assoc]
+  --
+  rw [associator_inv_naturality_middle_assoc]
+  -- and again...
+  rw [← MonoidalCategory.comp_whiskerRight_assoc]
+  rw [braiding_naturality_right]
+  rw [MonoidalCategory.comp_whiskerRight_assoc]
+  --
+  rw [associator_naturality_left_assoc]
+  rw [← whisker_exchange_assoc]
+  simp only [Functor.id_obj]
+  rw [EhomPrecompose_selfEval_comp_eq]
+
+  -- There are no more pre's in the equation
+  --Very bad
+  have : β_ ((ihom v).obj w) v = β_ (Ehom V V v w) v := rfl
+  rw [this]
+  --
+  rw [braiding_naturality_right_assoc]
+  simp only [braiding_tensor_right, Functor.id_obj, Category.assoc,
+    Iso.hom_inv_id_assoc]
+  rw [← comp_whiskerRight_assoc]
+  simp only [symmetry, id_whiskerRight, Category.id_comp, Iso.inv_hom_id_assoc]
+  rw [← MonoidalCategory.whiskerLeft_comp_assoc]
+  simp only [symmetry, MonoidalCategory.whiskerLeft_id, Category.id_comp]
+  -- Forced to unfold uncurry
+  rw [uncurry_eq]
+  rw [(ihom.ev_naturality u)]
+  -- lemma about the enriched structure on V
+  have : eComp V u v w = comp u v w := rfl
+  rw [this]
+  have : u ◁ comp u v w ≫ (ihom.ev u).app w
+    = uncurry (comp u v w) := rfl
+  have := eq_whisker this wx.cone
+  simp only [Category.assoc] at this
+  rw [this]
+  rw [comp_eq]
+  rw [uncurry_curry]
+  rw [MonoidalClosed.compTranspose_eq]
+  simp only [Category.assoc]
+  exact rfl
+
+theorem precompose_id_eq {x : C} {v : V} (vx : Cotensor v x) :
+    eId V v ≫ EhomPrecompose V vx vx = eId V vx.obj := by
+  -- Copied from the last proof
+  apply (cancel_mono (vx.coneNatTrans _)).mp
+  simp only [Category.assoc]
+  rw [EhomPrecompose_coneNatTrans_eq]
+  apply uncurry_injective
+  simp only [uncurry_natural_left]
+  rw [vx.coneNatTrans_eq]
+  simp only [braiding_naturality_right_assoc, braiding_tensorUnit_right,
+    Category.assoc]
+  rw [uncurry_eq]
+
+  -- apply (Iso.inv_comp_eq _).mp
+  -- Moving selfEval up on the LHS
+  -- rw [whisker_exchange_assoc]
+  -- rw [← rightUnitor_inv_naturality_assoc]
+  -- Moving up selfEval on the RHS
+  rw [← whisker_exchange_assoc]
+  rw [← leftUnitor_inv_naturality_assoc]
+  simp only [e_id_comp, Category.comp_id]
+  rw [ihom.ev_naturality]
+
+  -- Annoying
+  have : eId V v = MonoidalClosed.id v := rfl
+  rw [this]
+  -- Even more annoying - this came up in the enriched thing!
+  rw [MonoidalClosed.id_eq]
+  have := uncurry_eq (curry (ρ_ v).hom)
+  have := eq_whisker this.symm vx.cone
+  simp only [Category.assoc] at this
+  rw [this]
+  --
+  rw [uncurry_curry]
+
+/-- Commutativity of postcomposition with precoposition -/
+theorem post_pre_eq_pre_post {x y : C} {w v : V} (wx : Cotensor w x) (wy : Cotensor w y)
+    (vx : Cotensor v x) (vy : Cotensor v y) :
+  (EhomPrecompose V wx vx ⊗ postcompose V wx wy) ≫ eComp V vx.obj wx.obj wy.obj =
+    (EhomPrecompose V wy vy ⊗ postcompose V vx vy) ≫ (β_ _ _).hom
+      ≫ eComp V vx.obj vy.obj wy.obj := by
+  -- Turn EHom to IHom, uncurry, and simplify the result
+  apply (cancel_mono (wy.coneNatTrans _)).mp
+  apply uncurry_injective
+  simp only [uncurry_natural_left]
+  unfold Precotensor.coneNatTrans
+  rw [uncurry_curry]
+  rw [MonoidalCategory.tensorHom_def]
+  simp only [MonoidalCategory.whiskerLeft_comp, Category.assoc]
+
+  -- Remove post w from the LHS
+  rw [braiding_naturality_right_assoc]
+  rw [braiding_naturality_right_assoc]
+  rw [← whisker_exchange_assoc]
+  -- simp only [MonoidalCategory.comp_whiskerRight]
+  -- simp only [Category.assoc]
+
+  rw [← (e_assoc' V vx.obj wx.obj wy.obj y)]
+
+  rw [associator_naturality_right_assoc]
+  rw [associator_naturality_middle_assoc]
+  rw [← MonoidalCategory.whiskerLeft_comp_assoc]
+  rw [← MonoidalCategory.whiskerLeft_comp_assoc]
+  simp only [Category.assoc]
+  rw [postcompose_selfEval_comp_eq]
+  simp only [MonoidalCategory.whiskerLeft_comp, Category.assoc]
+
+  -- Remove pre x from the LHS
+  rw [braiding_tensor_right_assoc]
+  rw [Iso.inv_hom_id_assoc]
+  -- This uses the symmetry!
+  rw [← MonoidalCategory.whiskerLeft_comp_assoc]
+  simp only [symmetry, whiskerLeft_id_assoc]
+  --
+  rw [associator_inv_naturality_middle_assoc]
+  -- Candidate for moving to its own lemma
+  rw [← comp_whiskerRight_assoc]
+  rw [braiding_naturality_right]
+  rw [comp_whiskerRight_assoc]
+  --
+  rw [← (e_assoc V vx.obj wx.obj x y)]
+  rw [← whisker_assoc_assoc]
+  repeat rw [← MonoidalCategory.comp_whiskerRight_assoc]
+  simp only [Category.assoc]
+  rw [EhomPrecompose_selfEval_comp_eq]
+
+  -- Remove pre y from the RHS
+  rw [MonoidalCategory.tensorHom_def']
+  simp only [MonoidalCategory.whiskerLeft_comp, Category.assoc]
+  rw [braiding_naturality_right_assoc]
+  rw [← whisker_exchange_assoc]
+  rw [← e_assoc']
+  rw [associator_naturality_right_assoc]
+  rw [braiding_tensor_right_assoc]
+  rw [Iso.inv_hom_id_assoc]
+  -- Candidate for moving to its own lemma
+  nth_rw 2 [← MonoidalCategory.whiskerLeft_comp_assoc]
+  rw [braiding_naturality_left]
+  rw [MonoidalCategory.whiskerLeft_comp_assoc]
+  --
+  rw [associator_inv_naturality_right_assoc]
+  rw [whisker_exchange_assoc]
+  rw [associator_naturality_right_assoc]
+  -- Candidate for moving to its own lemma
+  nth_rw 2 [← MonoidalCategory.whiskerLeft_comp_assoc]
+  rw [braiding_naturality_right]
+  --
+  nth_rw 2 [← MonoidalCategory.whiskerLeft_comp_assoc]
+  nth_rw 2 [← MonoidalCategory.whiskerLeft_comp_assoc]
+  simp only [Category.assoc]
+  rw [EhomPrecompose_selfEval_comp_eq]
+  -- Very bad
+
+  have t := symmetry_assoc w (Ehom V V w v) ((ihom.ev w).app v ≫ vy.cone)
+  have u : (β_ (Ehom V V w v) w).hom = (β_ ((ihom w).obj v) w).hom := rfl
+  rw [u] at t
+  rw [t]
+  --
+
+  -- Remove post x from the RHS
+  simp only [MonoidalCategory.whiskerLeft_comp, Category.assoc]
+  -- Candidate again...
+  rw [← MonoidalCategory.whiskerLeft_comp_assoc]
+  rw [braiding_naturality_right]
+  rw [MonoidalCategory.whiskerLeft_comp_assoc]
+  --
+  rw [associator_inv_naturality_middle_assoc]
+  -- Candidate on the right
+  rw [← MonoidalCategory.comp_whiskerRight_assoc]
+  rw [braiding_naturality_right]
+  nth_rw 2 [MonoidalCategory.comp_whiskerRight_assoc]
+  --
+  rw [associator_naturality_left_assoc]
+  rw [← whisker_exchange_assoc]
+  simp only [Functor.id_obj]
+  rw [postcompose_selfEval_comp_eq]
+
+  -- There are no more post's or pre's in the equation
+  simp only [comp_whiskerRight, Category.assoc, braiding_naturality_right_assoc,
+    braiding_tensor_right, Iso.hom_inv_id_assoc]
+  rw [← comp_whiskerRight_assoc]
+  -- Very bad again...
+  have t' := symmetry w (Ehom V V w v)
+  have u' : (β_ (Ehom V V w v) w).hom = (β_ ((ihom w).obj v) w).hom := rfl
+  rw [u'] at t'
+  rw [t']
+  --
+  nth_rw 3 [← comp_whiskerRight_assoc]
+  simp only [symmetry, id_whiskerRight, Category.id_comp, Iso.inv_hom_id_assoc]
+  rw [← MonoidalCategory.whiskerLeft_comp_assoc]
+  simp only [symmetry, MonoidalCategory.whiskerLeft_id, Category.id_comp]
+
+class CotensoredCategory (V : Type u) [Category.{u₁} V] [MonoidalCategory V] [MonoidalClosed V]
+    [SymmetricCategory V] (C : Type v) [EnrichedCategory V C] where
+  cotensor : (v : V) → (x : C) → Cotensor v x
+
+open CotensoredCategory eOpposite
+
+def cotensor_bifunc [CotensoredCategory V C] : EnrichedFunctor V ((eOpposite V V) ⊗[V] C) C :=
+  enrichedTensor.eBifuncConstr V (eOpposite V V) C
+    (fun v x ↦ (cotensor (unop V v) x).obj)
+    (fun v w x ↦ EhomPrecompose V (cotensor (unop V w) x) (cotensor (unop V v) x))
+    (fun v x y ↦ postcompose V (cotensor (unop V v) x) (cotensor (unop V v) y))
+    (fun v x ↦ precompose_id_eq V (cotensor (unop V v) x))
+    (fun v x ↦ postcompose_id_eq V (cotensor (unop V v) x))
+    (fun u v w x ↦ by
+      have : eComp V u v w = (β_ _ _).hom ≫ eComp V (unop V w) (unop V v) (unop V u) := rfl
+      simp only [this, Category.assoc]
+      rw [SymmetricCategory.braiding_swap_eq_inv_braiding]
+      apply (Iso.inv_comp_eq _).mpr
+      rw [← BraidedCategory.braiding_naturality_assoc]
+      exact precompose_comp_eq V
+        (cotensor (unop V w) x) (cotensor (unop V v) x) (cotensor (unop V u) x))
+    (fun v x y z ↦ postcompose_comp_eq V
+      (cotensor (unop V v) x)
+      (cotensor (unop V v) y)
+      (cotensor (unop V v) z))
+    (fun w v x y ↦ post_pre_eq_pre_post V
+      (cotensor (unop V v) x)
+      (cotensor (unop V v) y)
+      (cotensor (unop V w) x)
+      (cotensor (unop V w) y))
+
+end Cotensor

--- a/InfinityCosmos/ForMathlib/CategoryTheory/Enriched/MonoidalProdCat.lean
+++ b/InfinityCosmos/ForMathlib/CategoryTheory/Enriched/MonoidalProdCat.lean
@@ -1,0 +1,204 @@
+/-
+Copyright (c) 2024 Daniel Carranza. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Daniel Carranza
+-/
+import Mathlib.CategoryTheory.Closed.Enrichment
+
+/-!
+
+# The monoidal product of enriched categories
+
+When a monoidal category `V` is braided, we may define the monoidal product of
+`V`-categories `C` and `D`, which is a `V`-category structure on the product type `C × D`.
+The "middle-four exchange" map (known as `tensor_μ`) is required to define the composition morphism.
+
+-/
+
+universe u₁ u₂ u₃ u₄ v₁
+
+namespace CategoryTheory
+
+open MonoidalCategory
+
+/-- The underlying type of the enriched tensor product of categories -/
+@[nolint unusedArguments]
+structure enrichedTensor (V : Type u₁) (C : Type u₂) (D : Type u₃) where
+  pr₁ : C
+  pr₂ : D
+
+namespace enrichedTensor
+
+notation C " ⊗[" V "] " D:10 => enrichedTensor V C D
+
+def of_prod (V : Type u₁) {C : Type u₂} {D : Type u₃} (p : C × D) : enrichedTensor V C D :=
+  ⟨p.1, p.2⟩
+
+def to_prod (V : Type u₁) {C : Type u₂} {D : Type u₃} (q : C ⊗[V] D) : C × D := ⟨q.pr₁, q.pr₂⟩
+
+@[simp]
+theorem to_of_prod (V : Type u₁) {C : Type u₂} {D : Type u₃} (p : C × D) :
+  to_prod V (of_prod V p) = p := rfl
+
+@[simp]
+theorem of_to_prod (V : Type u₁) {C : Type u₂} {D : Type u₃} (p : C ⊗[V] D) :
+  of_prod V (to_prod V p) = p := rfl
+
+/-- The type-level equivalence between the product type and the enriched tensor. -/
+def equivToEnrichedOpposite (V : Type u₁) (C : Type u₂) (D : Type u₃) :
+    C × D ≃ C ⊗[V] D where
+  toFun := of_prod V
+  invFun := to_prod V
+  left_inv := by aesop_cat
+  right_inv := by aesop_cat
+
+variable (V : Type u₁) [Category.{v₁} V] [MonoidalCategory V]
+variable (C : Type u₂) [EnrichedCategory V C]
+variable (D : Type u₃) [EnrichedCategory V D]
+
+-- Helper lemma for Bifunc.mk
+lemma comp_tensor_comp_eq_comp_mid_left_right {a b c d e : C} :
+    ((eComp V a b c) ⊗ (eComp V c d e)) ≫ eComp V a c e =
+      (α_ _ _ _).hom ≫ _ ◁ (α_ _ _ _).inv ≫ _ ◁ ((eComp V b c d) ▷ _) ≫ _ ◁ (eComp V b d e) ≫
+        eComp V a b e := by
+  rw [← MonoidalCategory.whiskerLeft_comp_assoc, ← MonoidalCategory.whiskerLeft_comp_assoc]
+  simp only [Category.assoc, e_assoc, MonoidalCategory.whiskerLeft_comp]
+  rw [← associator_naturality_right_assoc, e_assoc', ← tensorHom_def'_assoc]
+
+variable [SymmetricCategory V]
+
+instance : EnrichedCategory V (C ⊗[V] D) where
+  Hom := fun ⟨c, d⟩ ⟨c', d'⟩ => EnrichedCategory.Hom c c' ⊗ EnrichedCategory.Hom d d'
+  id := fun ⟨c, d⟩ => (λ_ (𝟙_ V)).inv ≫ (EnrichedCategory.id c ⊗ EnrichedCategory.id d)
+  comp := fun ⟨c, d⟩ ⟨c', d'⟩ ⟨c'', d''⟩ => tensor_μ _ _ _ _ ≫
+    (EnrichedCategory.comp _ _ _ ⊗ EnrichedCategory.comp _ _ _)
+  id_comp := fun ⟨c, d⟩ ⟨c', d'⟩ => by
+    simp only [comp_whiskerRight_assoc, tensor_μ_natural_left_assoc]
+    have := tensor_left_unitality (EnrichedCategory.Hom c c' : V) (EnrichedCategory.Hom d d')
+    rw [← Category.assoc] at this
+    have := (Iso.comp_inv_eq
+      (tensorIso (λ_ (EnrichedCategory.Hom c c')) (λ_ (EnrichedCategory.Hom d d')))).mpr this
+    slice_lhs 2 3 => rw [← this]
+    simp only [tensorIso_inv, Category.assoc, Iso.inv_hom_id_assoc]
+    rw [← tensor_comp, ← tensor_comp, EnrichedCategory.id_comp, EnrichedCategory.id_comp]
+    exact tensor_id (EnrichedCategory.Hom c c') (EnrichedCategory.Hom d d')
+  comp_id := fun ⟨c, d⟩ ⟨c', d'⟩ => by
+    simp only [MonoidalCategory.whiskerLeft_comp_assoc, tensor_μ_natural_right_assoc]
+    have := tensor_right_unitality (EnrichedCategory.Hom c c' : V) (EnrichedCategory.Hom d d')
+    rw [← Category.assoc] at this
+    have := (Iso.comp_inv_eq
+      (tensorIso (ρ_ (EnrichedCategory.Hom c c')) (ρ_ (EnrichedCategory.Hom d d')))).mpr this
+    slice_lhs 2 3 => rw [← this]
+    simp only [tensorIso_inv, Category.assoc, Iso.inv_hom_id_assoc]
+    rw [← tensor_comp, ← tensor_comp, EnrichedCategory.comp_id, EnrichedCategory.comp_id]
+    exact tensor_id (EnrichedCategory.Hom c c') (EnrichedCategory.Hom d d')
+  assoc := fun ⟨c₁, d₁⟩ ⟨c₂, d₂⟩ ⟨c₃, d₃⟩ ⟨c₄, d₄⟩ => by
+    simp only [comp_whiskerRight_assoc, MonoidalCategory.whiskerLeft_comp_assoc,
+      tensor_μ_natural_left_assoc, tensor_μ_natural_right_assoc]
+    apply (Iso.inv_comp_eq _).mpr
+    rw [← tensor_associativity_assoc]
+    repeat rw [← tensor_comp]
+    apply whisker_eq; apply whisker_eq
+    rw [(Iso.inv_comp_eq _).mp (@EnrichedCategory.assoc V _ _ C _ c₁ c₂ c₃ c₄),
+      (Iso.inv_comp_eq _).mp (@EnrichedCategory.assoc V _ _ D _ d₁ d₂ d₃ d₄)]
+
+-- Look up if there is an analogous lemma for the unenriched setting
+def eBifuncConstr {E : Type u₄} [EnrichedCategory V E]
+    (F_obj : C → D → E)
+    (F_map_left : (c c' : C) → (d : D) →
+      (c ⟶[V] c') ⟶ EnrichedCategory.Hom (F_obj c d) (F_obj c' d))
+    (F_map_right : (c : C) → (d d' : D) →
+      (d ⟶[V] d') ⟶ EnrichedCategory.Hom (F_obj c d) (F_obj c d'))
+    (F_id_left : (c : C) → (d : D) →
+      eId V c ≫ F_map_left c c d = eId V _)
+    (F_id_right : (c : C) → (d : D) →
+      eId V d ≫ F_map_right c d d = eId V _)
+    (F_comp_left : (c c' c'' : C) → (d : D) →
+      eComp V c c' c'' ≫ F_map_left c c'' d = ((F_map_left c c' d) ⊗ (F_map_left c' c'' d)) ≫ eComp V _ _ _)
+    (F_comp_right : (c : C) → (d d' d'' : D) →
+      eComp V d d' d'' ≫ F_map_right c d d'' = ((F_map_right c d d') ⊗ (F_map_right c d' d'')) ≫ eComp V _ _ _)
+    (F_left_right_naturality : (c c' : C) → (d d' : D) →
+      ((F_map_left c c' d) ⊗ (F_map_right c' d d')) ≫ eComp V _ _ _ = ((F_map_left c c' d') ⊗ (F_map_right c d d')) ≫ (β_ _ _).hom ≫ eComp V _ _ _)
+    : EnrichedFunctor V (C ⊗[V] D) E where
+  obj p := F_obj p.pr₁ p.pr₂
+  map p q := ((F_map_left p.pr₁ q.pr₁ p.pr₂) ⊗ (F_map_right q.pr₁ p.pr₂ q.pr₂)) ≫ eComp V _ _ _
+  map_id p := by
+    have : eId V p = (λ_ _).inv ≫ ((eId V p.pr₁) ⊗ (eId V p.pr₂)) := rfl
+    simp only [this, Category.assoc]
+    rw [← tensor_comp_assoc]
+    simp only [F_id_left, F_id_right, tensorHom_def', Category.assoc]
+    rw [← leftUnitor_inv_naturality_assoc, e_id_comp]
+    exact Category.comp_id (eId V (F_obj p.pr₁ p.pr₂))
+  map_comp p q r := by
+    have : eComp V p q r = tensor_μ _ _ _ _ ≫
+      (tensorHom (eComp V p.pr₁ q.pr₁ r.pr₁) (eComp V p.pr₂ q.pr₂ r.pr₂)) := rfl
+    simp only [this, Category.assoc]
+    rw [← tensor_comp_assoc, F_comp_left, F_comp_right]
+    simp only [tensor_comp_assoc]
+    rw [comp_tensor_comp_eq_comp_mid_left_right]
+    simp only [associator_naturality_assoc]
+    rw [← id_tensorHom]
+    rw [← tensor_comp_assoc]
+    rw [associator_inv_naturality]
+    have F_left_id : F_map_left p.pr₁ q.pr₁ p.pr₂ ≫ 𝟙 _ = 𝟙 _ ≫ F_map_left p.pr₁ q.pr₁ p.pr₂ := by aesop_cat
+    rw [F_left_id, tensor_comp_assoc]
+    rw [← tensorHom_id, ← id_tensorHom]
+    nth_rw 2 [← tensor_comp_assoc]
+    rw [← tensor_comp]
+    simp only [F_left_right_naturality]
+    rw [BraidedCategory.braiding_naturality_assoc]
+    have F_right_id : F_map_right r.pr₁ q.pr₂ r.pr₂ ≫ 𝟙 _ = 𝟙 _ ≫ F_map_right r.pr₁ q.pr₂ r.pr₂ := by aesop_cat
+    rw [F_right_id]
+    rw [tensor_comp]
+    rw [F_left_id]
+    rw [tensor_comp]
+    --
+    simp only [id_tensorHom, tensorHom_id]
+    unfold tensor_μ
+    simp only [Category.assoc]
+    simp only [Iso.inv_hom_id_assoc, whiskerLeft_hom_inv_assoc]
+    nth_rw 2 [← MonoidalCategory.whiskerLeft_comp_assoc]
+    rw [← MonoidalCategory.comp_whiskerRight]
+    rw [SymmetricCategory.symmetry]
+    simp only [id_whiskerRight, MonoidalCategory.whiskerLeft_id, Category.id_comp]
+
+    rw [tensorHom_def]
+    rw [@tensorHom_def' V _ _ _ _ _ _
+                    ((F_map_right q.pr₁ p.pr₂ q.pr₂ ⊗ F_map_left q.pr₁ r.pr₁ q.pr₂) ≫
+                      eComp V (F_obj q.pr₁ p.pr₂) (F_obj q.pr₁ q.pr₂) (F_obj r.pr₁ q.pr₂))
+                    (F_map_right r.pr₁ q.pr₂ r.pr₂)]
+    simp only [comp_whiskerRight]
+    -- simp only [Category.assoc]
+    simp only [MonoidalCategory.whiskerLeft_comp, Category.assoc]
+    nth_rw 3 [← MonoidalCategory.whiskerLeft_comp_assoc]
+
+    rw [← e_assoc']
+    rw [MonoidalCategory.whiskerLeft_comp_assoc]
+    rw [MonoidalCategory.whiskerLeft_comp_assoc]
+    nth_rw 2 [← MonoidalCategory.whiskerLeft_comp_assoc]
+    nth_rw 2 [← tensorHom_id]
+    rw [associator_naturality]
+    rw [MonoidalCategory.whiskerLeft_comp_assoc]
+    rw [← MonoidalCategory.whiskerLeft_comp_assoc]
+    rw [associator_naturality_right]
+    rw [MonoidalCategory.whiskerLeft_comp_assoc]
+    rw [← whisker_exchange_assoc]
+    rw [← MonoidalCategory.whiskerLeft_comp_assoc]
+    simp only [Iso.inv_hom_id, MonoidalCategory.whiskerLeft_id, Category.id_comp]
+
+    rw [← e_assoc]
+    rw [associator_inv_naturality_right_assoc]
+    nth_rw 4 [← id_tensorHom]
+    rw [associator_inv_naturality_assoc]
+    rw [associator_inv_naturality_right_assoc]
+    rw [associator_inv_naturality_left_assoc]
+    simp only [Iso.hom_inv_id_assoc]
+
+    rw [← tensorHom_id, ← tensorHom_id, ← id_tensorHom, ← id_tensorHom]
+    rw [← tensor_comp_assoc, ← tensor_comp_assoc]
+    simp only [Category.comp_id, Category.id_comp, id_tensorHom, tensorHom_id]
+    rw [← tensorHom_def, ← tensorHom_def', ← tensorHom_def'_assoc]
+
+end enrichedTensor
+
+end CategoryTheory

--- a/InfinityCosmos/ForMathlib/CategoryTheory/Enriched/MonoidalProdCat.lean
+++ b/InfinityCosmos/ForMathlib/CategoryTheory/Enriched/MonoidalProdCat.lean
@@ -65,7 +65,9 @@ lemma comp_tensor_comp_eq_comp_mid_left_right {a b c d e : C} :
   simp only [Category.assoc, e_assoc, MonoidalCategory.whiskerLeft_comp]
   rw [← associator_naturality_right_assoc, e_assoc', ← tensorHom_def'_assoc]
 
-variable [SymmetricCategory V]
+section
+
+variable [BraidedCategory V]
 
 instance : EnrichedCategory V (C ⊗[V] D) where
   Hom := fun ⟨c, d⟩ ⟨c', d'⟩ => EnrichedCategory.Hom c c' ⊗ EnrichedCategory.Hom d d'
@@ -101,6 +103,10 @@ instance : EnrichedCategory V (C ⊗[V] D) where
     apply whisker_eq; apply whisker_eq
     rw [(Iso.inv_comp_eq _).mp (@EnrichedCategory.assoc V _ _ C _ c₁ c₂ c₃ c₄),
       (Iso.inv_comp_eq _).mp (@EnrichedCategory.assoc V _ _ D _ d₁ d₂ d₃ d₄)]
+
+end
+
+variable [SymmetricCategory V]
 
 -- Look up if there is an analogous lemma for the unenriched setting
 def eBifuncConstr {E : Type u₄} [EnrichedCategory V E]

--- a/InfinityCosmos/ForMathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/InfinityCosmos/ForMathlib/CategoryTheory/Enriched/Opposite.lean
@@ -30,20 +30,20 @@ structure eOpposite (V : Type u₁) (C : Type u) where
 
 namespace eOpposite
 
-def mk_op (V : Type u₁) {C : Type u} (x : C) : eOpposite V C := ⟨x⟩
+def op {V : Type u₁} {C : Type u} (x : C) : eOpposite V C := ⟨x⟩
 
-def unop (V : Type u₁) {C : Type u} (x : eOpposite V C) : C := x.as
-
-@[simp]
-theorem mk_op_of_unop (V : Type u₁) {C : Type u} (x : eOpposite V C) : mk_op V (unop V x) = x := rfl
+def unop {V : Type u₁} {C : Type u} (x : eOpposite V C) : C := x.as
 
 @[simp]
-theorem unop_of_mk_op (V : Type u₁) {C : Type u} (x : C) :  unop V (mk_op V x) = x := rfl
+theorem op_of_unop (V : Type u₁) {C : Type u} (x : eOpposite V C) : op (unop x) = x := rfl
+
+@[simp]
+theorem unop_of_op (V : Type u₁) {C : Type u} (x : C) :  unop (V := V) (op x) = x := rfl
 
 /-- The type-level equivalence between a type and its enriched opposite. -/
 def equivToEnrichedOpposite (V : Type u₁) (C : Type u) : C ≃ eOpposite V C where
-  toFun := mk_op V
-  invFun := unop V
+  toFun := op
+  invFun := unop
   left_inv := by aesop_cat
   right_inv := by aesop_cat
 
@@ -64,7 +64,6 @@ instance EnrichedCategory.opposite : EnrichedCategory V (eOpposite V C) where
       Category.assoc, Iso.inv_hom_id_assoc]
     exact EnrichedCategory.id_comp _ _
   assoc _ _ _ _ := by
-    dsimp
     simp only [braiding_naturality_left_assoc,
       MonoidalCategory.whiskerLeft_comp, Category.assoc]
     rw [← EnrichedCategory.assoc]

--- a/InfinityCosmos/ForMathlib/CategoryTheory/Enriched/Opposite.lean
+++ b/InfinityCosmos/ForMathlib/CategoryTheory/Enriched/Opposite.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2024 Daniel Carranza. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Daniel Carranza
+-/
+import Mathlib.CategoryTheory.Closed.Enrichment
+
+/-!
+
+# The opposite category of an enriched category
+
+When a monoidal category `V` is braided, we may define the opposite `V`-category of a
+`V`-cagtegory. The symmetry map is required to define the composition morphism.
+
+-/
+
+universe v₁ u₁ v u
+
+namespace CategoryTheory
+
+open BraidedCategory
+
+/-- The underlying type of the enriched opposite category.
+
+This takes `V` as an argument so that, if `C` is enriched over multiple categories,
+the instances of the underlying categories on `ForgetEnrichment C` do not coincide -/
+@[nolint unusedArguments]
+structure eOpposite (V : Type u₁) (C : Type u) where
+  as : C
+
+namespace eOpposite
+
+def mk_op (V : Type u₁) {C : Type u} (x : C) : eOpposite V C := ⟨x⟩
+
+def unop (V : Type u₁) {C : Type u} (x : eOpposite V C) : C := x.as
+
+@[simp]
+theorem mk_op_of_unop (V : Type u₁) {C : Type u} (x : eOpposite V C) : mk_op V (unop V x) = x := rfl
+
+@[simp]
+theorem unop_of_mk_op (V : Type u₁) {C : Type u} (x : C) :  unop V (mk_op V x) = x := rfl
+
+/-- The type-level equivalence between a type and its enriched opposite. -/
+def equivToEnrichedOpposite (V : Type u₁) (C : Type u) : C ≃ eOpposite V C where
+  toFun := mk_op V
+  invFun := unop V
+  left_inv := by aesop_cat
+  right_inv := by aesop_cat
+
+variable (V : Type u₁) [Category.{v₁} V] [MonoidalCategory V] [BraidedCategory V]
+variable (C : Type u) [EnrichedCategory V C]
+
+/-- The enriched category structure on `eOpposite V C` -/
+instance EnrichedCategory.opposite : EnrichedCategory V (eOpposite V C) where
+  Hom y x := EnrichedCategory.Hom x.unop y.unop
+  id x := EnrichedCategory.id x.unop
+  comp z y x := (β_ _ _).hom ≫ EnrichedCategory.comp (x.unop) (y.unop) (z.unop)
+  id_comp _ _ := by
+    simp only [braiding_naturality_left_assoc, braiding_tensorUnit_left,
+      Category.assoc, Iso.inv_hom_id_assoc]
+    exact EnrichedCategory.comp_id _ _
+  comp_id _ _ := by
+    simp only [braiding_naturality_right_assoc, braiding_tensorUnit_right,
+      Category.assoc, Iso.inv_hom_id_assoc]
+    exact EnrichedCategory.id_comp _ _
+  assoc _ _ _ _ := by
+    dsimp
+    simp only [braiding_naturality_left_assoc,
+      MonoidalCategory.whiskerLeft_comp, Category.assoc]
+    rw [← EnrichedCategory.assoc]
+    simp only [braiding_tensor_left, Category.assoc, Iso.inv_hom_id_assoc,
+      braiding_naturality_right_assoc, braiding_tensor_right]
+
+end eOpposite
+
+end CategoryTheory


### PR DESCRIPTION
This adds the definition of V-cotensors in a V-category, and a proof that if a V-category admits V-cotensors then these form an enriched bifunctor. In order to state and prove these results, some results are also included relating to the opposite V-category and the tensor product of V-categories.

This code is very unpolished with known stylistic flaws. Any suggestions to improve the proofs, the code, and/or the file structure are very welcome!