### PR TITLE
flip pullback squares and construct isofibrations

### DIFF
--- a/InfinityCosmos.lean
+++ b/InfinityCosmos.lean
@@ -3,6 +3,7 @@ import InfinityCosmos.ForMathlib.AlgebraicTopology.Quasicategory.Basic
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplexCategory
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialCategory.Basic
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialCategory.Cotensors
+import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialCategory.IsConicalTerminal
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialCategory.Limits
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.CoherentIso
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.Homotopy

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/Cotensors.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/Cotensors.lean
@@ -43,8 +43,8 @@ lemma cotensorPrecompose_homEquiv {U V : SSet} {A : K} (ua : Cotensor U A) (va :
 theorem cotensor_local_bifunctoriality {U V : SSet} {A B : K}
     (ua : Cotensor U A) (ub : Cotensor U B) (va : Cotensor V A) (vb : Cotensor V B)
     (i : U ⟶ V) (f : A ⟶ B) :
-    (cotensorPostcompose va vb f) ≫ (cotensorPrecompose ub vb i) =
-      (cotensorPrecompose ua va i) ≫ (cotensorPostcompose ua ub f) := by
+    (cotensorPrecompose ua va i) ≫ (cotensorPostcompose ua ub f) =
+      (cotensorPostcompose va vb f) ≫ (cotensorPrecompose ub vb i) := by
   apply (eHomEquiv SSet).injective
   rw [eHomEquiv_comp, eHomEquiv_comp]
   have thm := Cotensor.post_pre_eq_pre_post _ ua ub va vb
@@ -52,7 +52,7 @@ theorem cotensor_local_bifunctoriality {U V : SSet} {A B : K}
   rw [Category.assoc, ← tensor_comp_assoc] at compeq
   rw [← cotensorPostcompose_homEquiv, ← cotensorPrecompose_homEquiv] at compeq
   rw [compeq]
-  slice_rhs 2 3 => rw [← tensor_comp, ← cotensorPostcompose_homEquiv, ← cotensorPrecompose_homEquiv]
+  slice_lhs 2 3 => rw [← tensor_comp, ← cotensorPostcompose_homEquiv, ← cotensorPrecompose_homEquiv]
   simp only [braiding_naturality, braiding_tensorUnit_right, Category.assoc,
     Iso.cancel_iso_inv_left]
   monoidal
@@ -130,9 +130,8 @@ noncomputable def cotensorContraMap {U V : SSet} (i : U ⟶ V) (A : K) : V ⋔ A
 
 -- DC: post_pre_eq_pre_post
 theorem cotensor_bifunctoriality {U V : SSet} (i : U ⟶ V) {A B : K} (f : A ⟶ B) :
-    (cotensorCovMap V f) ≫ (cotensorContraMap i B) =
-    (cotensorContraMap i A) ≫ (cotensorCovMap U f) := cotensor_local_bifunctoriality _ _ _ _ i f
-
+    (cotensorContraMap i A) ≫ (cotensorCovMap U f) =
+      (cotensorCovMap V f) ≫ (cotensorContraMap i B) := cotensor_local_bifunctoriality _ _ _ _ i f
 end
 
 

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/IsConicalTerminal.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/IsConicalTerminal.lean
@@ -17,16 +17,15 @@ abbrev IsConicalTerminal (T : C) := IsSLimit (asEmptyCone T)
 def IsConicalTerminal.isTerminal {T : C} (hT : IsConicalTerminal T) : IsTerminal T := hT.isLimit
 
 /-- The defining universal property of a conical terminal object gives an isomorphism of homs.-/
-def IsConicalTerminal.sHomIso {T : C} (hT : IsConicalTerminal T) (X : C) : sHom X T ≅ ⊤_ SSet := by
-  let iso : sHom X T ≅ _ := limitComparisonIso _ X hT
-  sorry
+noncomputable def IsConicalTerminal.sHomIso {T : C} (hT : IsConicalTerminal T)
+    (X : C) : sHom X T ≅ ⊤_ SSet :=
+  limitComparisonIso _ X hT ≪≫
+    HasLimit.isoOfEquivalence (by rfl) (Functor.emptyExt _ _)
 
-/-- Transport a term of type `IsTerminal` across an isomorphism. -/
-def IsConicalTerminal.ofIso {Y Z : C} (hY : IsConicalTerminal Y) (i : Y ≅ Z) :
-    IsConicalTerminal Z := sorry
-  -- IsLimit.ofIsoLimit hY
-  --   { hom := { hom := i.hom }
-  --     inv := { hom := i.inv } }
+/-- Transport a term of type `IsConicalTerminal` across an isomorphism. -/
+noncomputable def IsConicalTerminal.ofIso {Y Z : C} (hY : IsConicalTerminal Y)
+    (i : Y ≅ Z) : IsConicalTerminal Z :=
+  hY.ofIsoSLimit <| Cones.ext i (by simp)
 
 namespace HasConicalTerminal
 variable [HasConicalTerminal C]
@@ -34,11 +33,11 @@ variable [HasConicalTerminal C]
 variable (C) in
 noncomputable def conicalTerminal : C := conicalLimit (Functor.empty.{0} C)
 
-def conicalTerminalIsConicalTerminal : IsConicalTerminal (conicalTerminal C) where
-  isLimit := sorry
-  isSLimit := sorry
+noncomputable def conicalTerminalIsConicalTerminal :
+    IsConicalTerminal (conicalTerminal C) :=
+  conicalLimit.isConicalLimit _ |>.ofIsoSLimit <| Cones.ext (by rfl) (by simp)
 
-def terminalIsConicalTerminal {T : C} (hT : IsTerminal T) :
+noncomputable def terminalIsConicalTerminal {T : C} (hT : IsTerminal T) :
     IsConicalTerminal T := by
   let TT := conicalLimit (Functor.empty.{0} C)
   let slim : IsConicalTerminal TT := conicalTerminalIsConicalTerminal

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/IsConicalTerminal.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/IsConicalTerminal.lean
@@ -1,0 +1,52 @@
+import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialCategory.Limits
+
+namespace CategoryTheory
+
+namespace SimplicialCategory
+
+universe u v
+
+open Limits
+
+variable {C : Type u} [Category.{v} C] [SimplicialCategory C]
+
+/-- `X` is conical terminal if the cone it induces on the empty diagram is a conical limit cone. -/
+abbrev IsConicalTerminal (T : C) := IsSLimit (asEmptyCone T)
+
+/-- A conical terminal object is also terminal.-/
+def IsConicalTerminal.isTerminal {T : C} (hT : IsConicalTerminal T) : IsTerminal T := hT.isLimit
+
+/-- The defining universal property of a conical terminal object gives an isomorphism of homs.-/
+def IsConicalTerminal.sHomIso {T : C} (hT : IsConicalTerminal T) (X : C) : sHom X T ≅ ⊤_ SSet := by
+  let iso : sHom X T ≅ _ := limitComparisonIso _ X hT
+  sorry
+
+/-- Transport a term of type `IsTerminal` across an isomorphism. -/
+def IsConicalTerminal.ofIso {Y Z : C} (hY : IsConicalTerminal Y) (i : Y ≅ Z) :
+    IsConicalTerminal Z := sorry
+  -- IsLimit.ofIsoLimit hY
+  --   { hom := { hom := i.hom }
+  --     inv := { hom := i.inv } }
+
+namespace HasConicalTerminal
+variable [HasConicalTerminal C]
+
+variable (C) in
+noncomputable def conicalTerminal : C := conicalLimit (Functor.empty.{0} C)
+
+def conicalTerminalIsConicalTerminal : IsConicalTerminal (conicalTerminal C) where
+  isLimit := sorry
+  isSLimit := sorry
+
+def terminalIsConicalTerminal {T : C} (hT : IsTerminal T) :
+    IsConicalTerminal T := by
+  let TT := conicalLimit (Functor.empty.{0} C)
+  let slim : IsConicalTerminal TT := conicalTerminalIsConicalTerminal
+  let lim : IsTerminal TT := IsConicalTerminal.isTerminal slim
+  exact IsConicalTerminal.ofIso slim (hT.uniqueUpToIso lim).symm
+
+end HasConicalTerminal
+
+end SimplicialCategory
+
+end CategoryTheory

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/Limits.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/Limits.lean
@@ -26,6 +26,19 @@ structure IsSLimit where
 /-- Conical simplicial limits are also limits in the unenriched sense.-/
 def IsSLimit_islimit (slim : IsSLimit c) : IsLimit c := slim.isLimit
 
+/-- Transport evidence that a cone is a simplicially enriched limit cone across
+an isomorphism of cones. -/
+noncomputable def IsSLimit.ofIsoSLimit {r t : Cone F} (h : IsSLimit r)
+    (i : r ≅ t) : IsSLimit t where
+  isLimit := h.isLimit.ofIsoLimit i
+  isSLimit X := h.isSLimit X |>.ofIsoLimit
+    { hom := Functor.mapConeMorphism _ i.hom
+      inv := Functor.mapConeMorphism _ i.inv
+      hom_inv_id := by
+        simp only [Functor.mapCone, Functor.mapConeMorphism, Iso.map_hom_inv_id]
+      inv_hom_id := by
+        simp only [Functor.mapCone, Functor.mapConeMorphism, Iso.map_inv_hom_id] }
+
 namespace SimplicialCategory
 
 /-!

--- a/InfinityCosmos/ForMathlib/InfinityCosmos/Basic.lean
+++ b/InfinityCosmos/ForMathlib/InfinityCosmos/Basic.lean
@@ -1,6 +1,5 @@
-import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialCategory.Basic
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialCategory.Cotensors
-import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialCategory.Limits
+import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialCategory.IsConicalTerminal
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.MorphismProperty
 import Mathlib.CategoryTheory.Closed.Cartesian
 import Mathlib.CategoryTheory.Limits.Shapes.Pullback.CommSq
@@ -56,8 +55,7 @@ variable (K : Type u) [Category.{v} K][PreInfinityCosmos.{v} K]
 class InfinityCosmos extends PreInfinityCosmos K where
   comp_isIsofibration {A B C : K} (f : A ↠ B) (g : B ↠ C) : IsIsofibration (f.1 ≫ g.1)
   iso_isIsofibration {X Y : K} (e : X ⟶ Y) [IsIso e] : IsIsofibration e
-  all_objects_fibrant {X Y : K} (hY : IsTerminal Y) (f : X ⟶ Y) : IsIsofibration f
-        -- TODO: replace by IsConicalTerminal?
+  all_objects_fibrant {X Y : K} (hY : IsConicalTerminal Y) (f : X ⟶ Y) : IsIsofibration f
   [has_products : HasConicalProducts K]
   prod_map_fibrant {γ : Type w} {A B : γ → K} (f : ∀ i, A i ↠ B i) :
     IsIsofibration (Limits.Pi.map (λ i ↦ (f i).1))
@@ -84,13 +82,17 @@ namespace InfinityCosmos
 
 variable {K : Type u} [Category.{v} K] [InfinityCosmos K]
 
-open InfinityCosmos PreInfinityCosmos
+open InfinityCosmos PreInfinityCosmos SimplicialCategory
 
 instance : HasConicalTerminal K := by infer_instance
 
-instance : HasCotensors K := by infer_instance
-
 instance : HasTerminal K := by infer_instance
+
+/-- The terminal object in an ∞-cosmos is a conical terminal object. -/
+def terminalIsConicalTerminal : IsConicalTerminal (⊤_ K) :=
+  HasConicalTerminal.terminalIsConicalTerminal terminalIsTerminal
+
+instance : HasCotensors K := by infer_instance
 
 instance : HasProducts K := by infer_instance
 

--- a/InfinityCosmos/ForMathlib/InfinityCosmos/Basic.lean
+++ b/InfinityCosmos/ForMathlib/InfinityCosmos/Basic.lean
@@ -54,16 +54,16 @@ variable (K : Type u) [Category.{v} K][PreInfinityCosmos.{v} K]
 
 /-- An `InfinityCosmos` extends a `PreInfinityCosmos` with limit and isofibration axioms..-/
 class InfinityCosmos extends PreInfinityCosmos K where
-  comp_isIsofibration {X Y Z : K} (f : X ↠ Y) (g : Y ↠ Z) : IsIsofibration (f.1 ≫ g.1)
+  comp_isIsofibration {A B C : K} (f : A ↠ B) (g : B ↠ C) : IsIsofibration (f.1 ≫ g.1)
   iso_isIsofibration {X Y : K} (e : X ⟶ Y) [IsIso e] : IsIsofibration e
   all_objects_fibrant {X Y : K} (hY : IsTerminal Y) (f : X ⟶ Y) : IsIsofibration f
         -- TODO: replace by IsConicalTerminal?
   [has_products : HasConicalProducts K]
   prod_map_fibrant {γ : Type w} {A B : γ → K} (f : ∀ i, A i ↠ B i) :
     IsIsofibration (Limits.Pi.map (λ i ↦ (f i).1))
-  [has_isoFibration_pullbacks {A B E : K} (f : A ⟶ B) (g : E ↠ B) : HasConicalPullback f g.1]
-  pullback_is_isoFibration {A B E P : K} (f : A ⟶ B) (g : E ↠ B)
-    (fst : P ⟶ A) (snd : P ⟶ E) (h : IsPullback fst snd f g.1) : IsIsofibration fst
+  [has_isoFibration_pullbacks {E B A : K} (p : E ↠ B) (f : A ⟶ B)  : HasConicalPullback p.1 f]
+  pullback_is_isoFibration {E B A P : K} (p : E ↠ B) (f : A ⟶ B)
+    (fst : P ⟶ E) (snd : P ⟶ A) (h : IsPullback fst snd p.1 f) : IsIsofibration snd
   [has_limits_of_towers (F : ℕᵒᵖ ⥤ K) :
     (∀ n : ℕ, IsIsofibration (F.map (homOfLE (Nat.le_succ n)).op)) → HasConicalLimit F]
   has_limits_of_towers_isIsofibration (F : ℕᵒᵖ ⥤ K) (hf) :
@@ -71,13 +71,12 @@ class InfinityCosmos extends PreInfinityCosmos K where
     IsIsofibration (limit.π F (.op 0))
   [has_cotensors : HasCotensors K]
   leibniz_cotensor  {U V : SSet} (i : U ⟶ V) [Mono i] {A B : K} (f : A ↠ B) {P : K}
-    (fst : P ⟶ V ⋔ B) (snd : P ⟶ U ⋔ A)
-    (h : IsPullback fst snd (cotensorContraMap i B) (cotensorCovMap U f)) :
+    (fst : P ⟶ U ⋔ A) (snd : P ⟶ V ⋔ B)
+    (h : IsPullback fst snd (cotensorCovMap U f.1) (cotensorContraMap i B)) :
     IsIsofibration (h.isLimit.lift <|
-      PullbackCone.mk (cotensorCovMap V f.1) (cotensorContraMap i A)
+      PullbackCone.mk (cotensorContraMap i A) (cotensorCovMap V f.1)
         (cotensor_bifunctoriality i f.1)) --TODO : Prove that these pullbacks exist.
   local_isoFibration {X A B : K} (f : A ↠ B) : Isofibration (toFunMap X f.1)
-
 
 attribute [instance] has_products has_isoFibration_pullbacks has_limits_of_towers has_cotensors
 

--- a/InfinityCosmos/ForMathlib/InfinityCosmos/Basic.lean
+++ b/InfinityCosmos/ForMathlib/InfinityCosmos/Basic.lean
@@ -89,7 +89,7 @@ instance : HasConicalTerminal K := by infer_instance
 instance : HasTerminal K := by infer_instance
 
 /-- The terminal object in an ∞-cosmos is a conical terminal object. -/
-def terminalIsConicalTerminal : IsConicalTerminal (⊤_ K) :=
+noncomputable def terminalIsConicalTerminal : IsConicalTerminal (⊤_ K) :=
   HasConicalTerminal.terminalIsConicalTerminal terminalIsTerminal
 
 instance : HasCotensors K := by infer_instance

--- a/InfinityCosmos/ForMathlib/InfinityCosmos/Isofibrations.lean
+++ b/InfinityCosmos/ForMathlib/InfinityCosmos/Isofibrations.lean
@@ -28,6 +28,9 @@ def compIsofibration {A B C : K} (f : A ↠ B) (g : B ↠ C) : A ↠ C :=
 theorem toTerminal_fibrant (A : K) : IsIsofibration (terminal.from A) :=
   all_objects_fibrant terminalIsTerminal _
 
+noncomputable def toTerminalIsofibration (A : K) : A ↠ (⊤_ K) :=
+  ⟨terminal.from A, toTerminal_fibrant A⟩
+
 theorem binary_prod_map_fibrant {X Y X' Y' : K} {f : X ↠ Y} {g : X' ↠ Y'} :
     IsIsofibration (prod.map f.1 g.1) := by sorry
 
@@ -45,6 +48,10 @@ noncomputable def cotensorInitialIso (A : K) : (⊥_ SSet ) ⋔ A ≅ ⊤_ K whe
 noncomputable instance cotensorInitial_isTerminal (A : K) : IsTerminal ((⊥_ SSet ) ⋔ A) :=
   terminalIsTerminal.ofIso (cotensorInitialIso A).symm
 
+lemma cotensorCovMapInitial_isIso {A B : K} (f : A ⟶ B) : IsIso (cotensorCovMap (⊥_ SSet) f) :=
+  isIso_of_isTerminal (cotensorInitial_isTerminal A) (cotensorInitial_isTerminal B)
+    (cotensorCovMap (⊥_ SSet) f)
+
 -- TODO: replace `cotensor.iso.underlying` with something for general cotensor API.
 noncomputable def cotensorToTerminalIso (U : SSet) {T : K} (hT : IsTerminal T) : U ⋔ T ≅ ⊤_ K where
   hom := terminal.from _
@@ -56,39 +63,43 @@ noncomputable def cotensorToTerminalIso (U : SSet) {T : K} (hT : IsTerminal T) :
 noncomputable instance cotensorToTerminal_isTerminal (U : SSet) {T : K} (hT : IsTerminal T) :
     IsTerminal (U ⋔ T) := terminalIsTerminal.ofIso (cotensorToTerminalIso U hT).symm
 
+lemma cotensorContraMapToTerminal_isIso {U V : SSet} (i : U ⟶ V) {T : K} (hT : IsTerminal T) :
+    IsIso (cotensorContraMap i T) :=
+  isIso_of_isTerminal (cotensorToTerminal_isTerminal V hT) (cotensorToTerminal_isTerminal U hT)
+    (cotensorContraMap i T)
+
 end terminal
 
-lemma initialSquare_isIso {A B : K} (f : A ⟶ B) : IsIso (cotensorCovMap (⊥_ SSet) f) :=
-  isIso_of_isTerminal (cotensorInitial_isTerminal A) (cotensorInitial_isTerminal B)
-    (cotensorCovMap (⊥_ SSet) f)
-
-lemma initialSquare_isPullback (V : SSet.{v}) {A B : K} (f : A ↠ B) :
+lemma cotensorInitialSquare_isPullback (V : SSet.{v}) {A B : K} (f : A ↠ B) :
     IsPullback (terminal.from (V ⋔ B) ≫ (cotensorInitialIso A).inv) (𝟙 _)
       (cotensorCovMap (⊥_ SSet) f.1) (cotensorContraMap (initial.to V) B) := by
-  have := initialSquare_isIso f.1
+  have := cotensorCovMapInitial_isIso f.1
   refine IsPullback.of_vert_isIso ?_
   constructor
   apply IsTerminal.hom_ext (cotensorInitial_isTerminal _)
 
 theorem cotensorCovMap_fibrant (V : SSet.{v}) {A B : K} (f : A ↠ B) :
     IsIsofibration (cotensorCovMap V f.1) := by
-  have := Initial.mono_to V
-  have := leibniz_cotensor (initial.to V) f _ _ (initialSquare_isPullback V f)
-  have := IsPullback.lift_snd (initialSquare_isPullback V f) (cotensorContraMap (initial.to V) A)
+  have := IsPullback.lift_snd
+    (cotensorInitialSquare_isPullback V f) (cotensorContraMap (initial.to V) A)
     (cotensorCovMap V f.1) (cotensor_bifunctoriality (initial.to V) f.1)
-  rw [comp_id] at this
-  rw [← this]
-  exact (leibniz_cotensor (initial.to V) f _ _ (initialSquare_isPullback V f))
+  rw [← this, comp_id]
+  exact (leibniz_cotensor (initial.to V) f _ _ (cotensorInitialSquare_isPullback V f))
+
+lemma cotensorTerminalSquare_isPullback {U V : SSet.{v}} (i : U ⟶ V) (A : K) :
+    IsPullback (𝟙 _) (terminal.from (U ⋔ A) ≫ (cotensorToTerminalIso V terminalIsTerminal).inv)
+      (cotensorCovMap U (terminal.from A)) (cotensorContraMap i (⊤_ K)) := by
+  have := cotensorContraMapToTerminal_isIso i (T := ⊤_ K) terminalIsTerminal
+  refine IsPullback.of_horiz_isIso ?_
+  constructor
+  apply IsTerminal.hom_ext (cotensorToTerminal_isTerminal U terminalIsTerminal)
 
 theorem cotensorContraMap_fibrant {U V : SSet} (i : U ⟶ V) [Mono i] (A : K) :
-    IsIsofibration (cotensorContraMap i A) := sorry
-
-  -- leibniz_cotensor  {U V : SSet} (i : U ⟶ V) [Mono i] {A B : K} (f : A ↠ B) {P : K}
-  --   (fst : P ⟶ U ⋔ A) (snd : P ⟶ V ⋔ B)
-  --   (h : IsPullback fst snd (cotensorCovMap U f.1) (cotensorContraMap i B)) :
-  --   IsIsofibration (h.isLimit.lift <|
-  --     PullbackCone.mk (cotensorContraMap i A) (cotensorCovMap V f.1)
-  --       (cotensor_bifunctoriality i f.1)) --TODO : Prove that these pullbacks exist.
-
+    IsIsofibration (cotensorContraMap i A) := by
+  have := IsPullback.lift_fst
+    (cotensorTerminalSquare_isPullback i A) (cotensorContraMap i A)
+    (cotensorCovMap V (terminal.from A)) (cotensor_bifunctoriality i (terminal.from A))
+  rw [← this, comp_id]
+  exact (leibniz_cotensor i (toTerminalIsofibration A) _ _ (cotensorTerminalSquare_isPullback i A))
 
 end InfinityCosmos

--- a/InfinityCosmos/ForMathlib/InfinityCosmos/Isofibrations.lean
+++ b/InfinityCosmos/ForMathlib/InfinityCosmos/Isofibrations.lean
@@ -26,7 +26,7 @@ def compIsofibration {A B C : K} (f : A ↠ B) (g : B ↠ C) : A ↠ C :=
   ⟨(f.1 ≫ g.1), comp_isIsofibration f g⟩
 
 theorem toTerminal_fibrant (A : K) : IsIsofibration (terminal.from A) :=
-  all_objects_fibrant terminalIsTerminal _
+  all_objects_fibrant terminalIsConicalTerminal _
 
 noncomputable def toTerminalIsofibration (A : K) : A ↠ (⊤_ K) :=
   ⟨terminal.from A, toTerminal_fibrant A⟩
@@ -53,20 +53,27 @@ lemma cotensorCovMapInitial_isIso {A B : K} (f : A ⟶ B) : IsIso (cotensorCovMa
     (cotensorCovMap (⊥_ SSet) f)
 
 -- TODO: replace `cotensor.iso.underlying` with something for general cotensor API.
-noncomputable def cotensorToTerminalIso (U : SSet) {T : K} (hT : IsTerminal T) : U ⋔ T ≅ ⊤_ K where
+noncomputable def cotensorToTerminalIso (U : SSet) {T : K} (hT : IsConicalTerminal T) :
+    U ⋔ T ≅ ⊤_ K where
   hom := terminal.from _
-  inv := (cotensor.iso.underlying U T (⊤_ K)).symm (by sorry)
-  hom_inv_id := (cotensor.iso.underlying U T (U ⋔ T)).injective
-    (by sorry)
+  inv := by
+    refine (cotensor.iso.underlying U T (⊤_ K)).symm ?_
+    exact (terminal.from U) ≫ (IsConicalTerminal.sHomIso hT (⊤_ K)).inv
+  hom_inv_id := by
+    apply (cotensor.iso.underlying U T (U ⋔ T)).injective
+    have : IsTerminal (sHom (U ⋔ T) T) :=
+      terminalIsTerminal.ofIso (IsConicalTerminal.sHomIso hT (U ⋔ T)).symm
+    apply IsTerminal.hom_ext this
   inv_hom_id := terminal.hom_ext _ _
 
-noncomputable instance cotensorToTerminal_isTerminal (U : SSet) {T : K} (hT : IsTerminal T) :
-    IsTerminal (U ⋔ T) := terminalIsTerminal.ofIso (cotensorToTerminalIso U hT).symm
+noncomputable instance cotensorToConicalTerminal_isTerminal
+    (U : SSet) {T : K} (hT : IsConicalTerminal T) : IsTerminal (U ⋔ T) :=
+  terminalIsTerminal.ofIso (cotensorToTerminalIso U hT).symm
 
-lemma cotensorContraMapToTerminal_isIso {U V : SSet} (i : U ⟶ V) {T : K} (hT : IsTerminal T) :
-    IsIso (cotensorContraMap i T) :=
-  isIso_of_isTerminal (cotensorToTerminal_isTerminal V hT) (cotensorToTerminal_isTerminal U hT)
-    (cotensorContraMap i T)
+lemma cotensorContraMapToTerminal_isIso {U V : SSet} (i : U ⟶ V)
+    {T : K} (hT : IsConicalTerminal T) : IsIso (cotensorContraMap i T) :=
+  isIso_of_isTerminal (cotensorToConicalTerminal_isTerminal V hT)
+    (cotensorToConicalTerminal_isTerminal U hT) (cotensorContraMap i T)
 
 end terminal
 
@@ -87,12 +94,13 @@ theorem cotensorCovMap_fibrant (V : SSet.{v}) {A B : K} (f : A ↠ B) :
   exact (leibniz_cotensor (initial.to V) f _ _ (cotensorInitialSquare_isPullback V f))
 
 lemma cotensorTerminalSquare_isPullback {U V : SSet.{v}} (i : U ⟶ V) (A : K) :
-    IsPullback (𝟙 _) (terminal.from (U ⋔ A) ≫ (cotensorToTerminalIso V terminalIsTerminal).inv)
+    IsPullback
+      (𝟙 _) (terminal.from (U ⋔ A) ≫ (cotensorToTerminalIso V terminalIsConicalTerminal).inv)
       (cotensorCovMap U (terminal.from A)) (cotensorContraMap i (⊤_ K)) := by
-  have := cotensorContraMapToTerminal_isIso i (T := ⊤_ K) terminalIsTerminal
+  have := cotensorContraMapToTerminal_isIso i (T := ⊤_ K) terminalIsConicalTerminal
   refine IsPullback.of_horiz_isIso ?_
   constructor
-  apply IsTerminal.hom_ext (cotensorToTerminal_isTerminal U terminalIsTerminal)
+  apply IsTerminal.hom_ext (cotensorToConicalTerminal_isTerminal U terminalIsConicalTerminal)
 
 theorem cotensorContraMap_fibrant {U V : SSet} (i : U ⟶ V) [Mono i] (A : K) :
     IsIsofibration (cotensorContraMap i A) := by


### PR DESCRIPTION
This PR flips the direction of the squares in the pullback axiom so that the displayed square matches the literature (with the isofibration drawn vertically on the right). 

This continues the project of constructing explicit isofibrations from the infinity cosmos axioms via unproven lemmas about conical terminal objects.