### PR TITLE
Strict segal homotopy category

### DIFF
--- a/InfinityCosmos.lean
+++ b/InfinityCosmos.lean
@@ -1,5 +1,6 @@
 import Mathlib.AlgebraicTopology.Quasicategory.Nerve
 import InfinityCosmos.ForMathlib.AlgebraicTopology.Quasicategory.Basic
+import InfinityCosmos.ForMathlib.AlgebraicTopology.Quasicategory.HomotopyCat
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplexCategory
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialCategory.Basic
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialCategory.Cotensors
@@ -9,6 +10,7 @@ import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.Homotopy
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.HomotopyCat
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.Monoidal
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.MorphismProperty
+import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.StrictSegal
 import InfinityCosmos.ForMathlib.CategoryTheory.Enriched.Cotensors
 import InfinityCosmos.ForMathlib.CategoryTheory.Enriched.MonoidalProdCat
 import InfinityCosmos.ForMathlib.CategoryTheory.MorphismProperty

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/Quasicategory/HomotopyCat.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/Quasicategory/HomotopyCat.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2024 Nick Ward. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nick Ward
+-/
+import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.Homotopy
+import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.HomotopyCat
+import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.StrictSegal
+import Mathlib.AlgebraicTopology.Quasicategory.Basic
+import Mathlib.AlgebraicTopology.SimplicialSet.StrictSegal
+
+universe u
+
+open SSet StrictSegal Simplicial
+
+namespace CategoryTheory.SSet
+
+open Opposite in
+instance (S : SSet.{u}) [StrictSegal S] : Category.{u} (OneTruncation S) where
+  id := 𝟙rq
+  comp {X Y Z} f g := by
+    refine ⟨?_, ?_⟩
+    · apply StrictSegal.spineToDiagonal (n := 2)
+      exact {
+        vertex := fun | 0 => X | 1 => Y | 2 => Z
+        arrow := fun | 0 => f.val | 1 => g.val
+        arrow_src := by
+          intro i
+          fin_cases i
+          · exact f.property.left
+          · exact g.property.left
+        arrow_tgt := by
+          intro i
+          fin_cases i
+          · exact f.property.right
+          · exact g.property.right }
+    · apply And.intro
+      · unfold OneTruncation.src
+        change S.δ 1 _ = X
+        rw [δ_one_spineToDiagonal]
+      · unfold OneTruncation.tgt
+        change S.δ 0 _ = Z
+        rw [δ_zero_spineToDiagonal]
+  id_comp {X Y} f := by
+    sorry
+  comp_id {X Y} f := by
+    sorry
+  assoc {W X Y Z} f g h := by
+    sorry
+
+end CategoryTheory.SSet

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplexCategory.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplexCategory.lean
@@ -9,4 +9,14 @@ namespace SimplexCategory
 def isTerminalZero : IsTerminal ([0] : SimplexCategory) :=
   IsTerminal.ofUniqueHom (fun _ ↦ const _ [0] 0) (fun _ _ => eq_const_to_zero _)
 
+lemma δ_one_diag {n : ℕ} : δ 1 ≫ diag n = const [0] [n] 0 := by
+  ext x
+  fin_cases x
+  rfl
+
+lemma δ_zero_diag {n : ℕ} : δ 0 ≫ diag n = const [0] [n] n := by
+  ext x
+  fin_cases x
+  rfl
+
 end SimplexCategory

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/Homotopy.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/Homotopy.lean
@@ -7,6 +7,7 @@ Authors: Johns Hopkins Category Theory Seminar
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.CoherentIso
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.Monoidal
 import Mathlib.CategoryTheory.Limits.Shapes.IsTerminal
+import Mathlib.AlgebraicTopology.SimplicialSet.StrictSegal
 
 universe u v w
 
@@ -119,6 +120,39 @@ def HomotopyL.refl : HomotopyL f f where
     rw [← Fin.succ_one_eq_two]
     rw [SimplicialObject.δ_comp_σ_succ A]
     rfl
+
+private lemma spine₂_arrow₀ (s : A _[2]) : (A.spine 2 s).arrow 0 = A.δ 2 s := by
+  simp only [SimplicialObject.δ, spine_arrow]
+  have : SimplexCategory.mkOfSucc 0 = SimplexCategory.δ 2 := by
+    ext i
+    fin_cases i <;> rfl
+  rw [this]
+
+private lemma spine₂_arrow₁ (s : A _[2]) : (A.spine 2 s).arrow 1 = A.δ 0 s := by
+  simp only [SimplicialObject.δ, spine_arrow]
+  have : SimplexCategory.mkOfSucc 1 = SimplexCategory.δ 0 := by
+    ext i
+    fin_cases i <;> rfl
+  rw [this]
+
+lemma StrictSegal.homotopic_iff_eq [StrictSegal A] : HomotopicL f g ↔ f = g := by
+  have hrfl := HomotopyL.refl f
+  apply Iff.intro <;> intro h
+  · have h := Classical.choice h
+    suffices A.spine 2 hrfl.simplex = A.spine 2 h.simplex by
+      rw [← hrfl.δ₁, ← h.δ₁]
+      rw [← spineToSimplex_spine hrfl.simplex, ← spineToSimplex_spine h.simplex]
+      rw [this]
+    ext i
+    fin_cases i
+    · simp only [spine₂_arrow₀, Fin.zero_eta]
+      rw [h.δ₂]
+      exact hrfl.δ₂
+    · simp only [spine₂_arrow₁, Fin.mk_one]
+      rw [h.δ₀]
+      exact hrfl.δ₀
+  · rw [← h]
+    exact Nonempty.intro hrfl
 
 end
 

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/Homotopy.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/Homotopy.lean
@@ -84,4 +84,42 @@ structure Equiv (A B : SSet.{u}) : Type u where
 
 end
 
+section
+
+variable {A : SSet.{u}} (f g : A _[1])
+
+structure HomotopyL where
+  simplex : A _[2]
+  δ₀ : A.δ 0 simplex = A.σ 0 (A.δ 0 f)
+  δ₁ : A.δ 1 simplex = g
+  δ₂ : A.δ 2 simplex = f
+
+def HomotopicL : Prop := Nonempty (HomotopyL f g)
+
+structure HomotopyR where
+  simplex : A _[2]
+  δ₀ : A.δ 0 simplex = f
+  δ₁ : A.δ 1 simplex = g
+  δ₂ : A.δ 2 simplex = A.σ 0 (A.δ 1 f)
+
+def HomotopicR : Prop := Nonempty (HomotopyR f g)
+
+def HomotopyL.refl : HomotopyL f f where
+  simplex := A.σ 1 f
+  δ₀ := by
+    rw [← types_comp_apply (A.σ _) (A.δ _), ← types_comp_apply (A.δ _) (A.σ _)]
+    rw [← Fin.succ_zero_eq_one, ← Fin.castSucc_zero]
+    rw [SimplicialObject.δ_comp_σ_of_le A (by rfl)]
+  δ₁ := by
+    rw [← types_comp_apply (A.σ _) (A.δ _)]
+    rw [SimplicialObject.δ_comp_σ_self' A (by rfl)]
+    rfl
+  δ₂ := by
+    rw [← types_comp_apply (A.σ _) (A.δ _)]
+    rw [← Fin.succ_one_eq_two]
+    rw [SimplicialObject.δ_comp_σ_succ A]
+    rfl
+
+end
+
 end SSet

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/StrictSegal.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/StrictSegal.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2024 Nick Ward. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nick Ward
+-/
+import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplexCategory
+import Mathlib.AlgebraicTopology.SimplicialSet.StrictSegal
+
+universe u
+
+open CategoryTheory SimplicialObject
+
+namespace SSet.StrictSegal
+variable {X : SSet.{u}} [StrictSegal X] {n : ℕ}
+
+lemma δ_one_spineToDiagonal (f : Path X n) :
+    X.δ 1 (spineToDiagonal f) = f.vertex 0 := by
+  simp only [spineToDiagonal, diagonal, SimplicialObject.δ]
+  rw [← FunctorToTypes.map_comp_apply, ← op_comp]
+  rw [SimplexCategory.δ_one_diag]
+  simp only [spineToSimplex_vertex]
+
+lemma δ_zero_spineToDiagonal (f : Path X n) :
+    X.δ 0 (spineToDiagonal f) = f.vertex n := by
+  simp only [spineToDiagonal, diagonal, SimplicialObject.δ]
+  rw [← FunctorToTypes.map_comp_apply, ← op_comp]
+  rw [SimplexCategory.δ_zero_diag]
+  simp only [spineToSimplex_vertex]
+
+end SSet.StrictSegal


### PR DESCRIPTION
This PR includes (partial) proofs of the following:
- Two 1-simplices in a `StrictSegal` simplicial set are homotopic if and only if they are equal.
- The `OneTruncation` of a `StrictSegal` simplicial set is a category.

To avoid translating back and forth between paths (defined by directed paths of edges of type `X _[1]`) and homotopies, I have used the definition of homotopies from [mathlib4#10006(comment)](https://github.com/leanprover-community/mathlib4/pull/10006#discussion_r1476794301). This differs slightly from the definition in #51. My tentative plan is to clean up the admitted proofs here, then open a new PR using the definition of homotopies from #51 for comparison.