### PR TITLE
ci: Use mathlib-update-action to stay in sync with Mathlib releases

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,23 +1,43 @@
 name: Update Dependencies
-
 on:
   schedule:             # Sets a schedule to trigger the workflow
-    - cron: "0 8 */7 * *" # Every 7 days at 08:00 AM UTC (for more info on the cron syntax see https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule)
+  - cron: "0 8 */7 * *" # Every 7 days at 08:00 AM UTC (for more info on the cron syntax see https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule)
   workflow_dispatch:    # Allows the workflow to be triggered manually via the GitHub interface
 
 jobs:
-  update_lean:
+  check-for-updates: # Determines which updates to apply.
+    runs-on: ubuntu-latest
+    outputs:
+      is-update-available: ${{ steps.check-for-updates.outputs.is-update-available }}
+      new-tags: ${{ steps.check-for-updates.outputs.new-tags }}
+    steps:
+      - name: Run the action
+        id: check-for-updates
+        uses: leanprover-community/mathlib-update-action@123565516a6e007991724176feaefcba2b90f627 # 2025-05-29
+        with:
+          # START CONFIGURATION BLOCK 1
+          legacy_update: true
+          # END CONFIGURATION BLOCK 1
+  do-update: # Runs the upgrade, tests it, and makes a PR/issue/commit.
     runs-on: ubuntu-latest
     permissions:
       contents: write      # Grants permission to push changes to the repository
       issues: write        # Grants permission to create or update issues
       pull-requests: write # Grants permission to create or update pull requests
+    needs: check-for-updates
+    if: ${{ needs.check-for-updates.outputs.is-update-available }}
+    strategy: # Runs for each update discovered by the `check-for-updates` job.
+      max-parallel: 1 # Ensures that the PRs/issues are created in order.
+      matrix:
+        tag: ${{ fromJSON(needs.check-for-updates.outputs.new-tags) }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Update project
-        uses: leanprover-community/lean-update@main
+      - name: Run the action
+        id: update-the-repo
+        uses: leanprover-community/mathlib-update-action/do-update@123565516a6e007991724176feaefcba2b90f627 # 2025-05-29
         with:
+          tag: ${{ matrix.tag }}
+          # START CONFIGURATION BLOCK 2
+          legacy_update: true
           on_update_succeeds: pr # Create a pull request if the update succeeds
           on_update_fails: issue # Create an issue if the update fails
-          legacy_update: true    # Executes lake -R -Kenv=dev update instead of lake update
+          # END CONFIGURATION BLOCK 2


### PR DESCRIPTION
This PR installs the `mathlib-update-action` to run dependency updates. This action keeps track of the Mathlib releases for new Lean versions and makes a PR/issue to update to such a release, before updating to the latest Mathlib master. Synchronizing to Mathlib releases ensures more compatibility between projects, since they will end up with dependencies at the same version.