### PR TITLE
ci: Use docgen-action to build the website.

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -54,90 +54,12 @@ jobs:
       - name: Get Mathlib cache
         run: ~/.elan/bin/lake exe cache get || true
 
-      - name: Cache API docs
-        uses: actions/cache@v4
-        with:
-          path: |
-            .lake/build/doc/Aesop
-            .lake/build/doc/Batteries
-            .lake/build/doc/find
-            .lake/build/doc/Init
-            .lake/build/doc/Lake
-            .lake/build/doc/Lean
-            .lake/build/doc/Mathlib
-            .lake/build/doc/Std
-          key: Docs-${{ hashFiles('lake-manifest.json') }}
-
       - name: Build project
         run: ~/.elan/bin/lake build InfinityCosmos
 
-      - name: Build project API documentation
-        run: ~/.elan/bin/lake -R -Kenv=dev build InfinityCosmos:docs
-
-      - name: Check for `home_page` folder # this is meant to detect a Jekyll-based website
-        id: check_home_page
-        run: |
-          if [ -d home_page ]; then
-            echo "The 'home_page' folder exists in the repository."
-            echo "HOME_PAGE_EXISTS=true" >> $GITHUB_ENV
-          else
-            echo "The 'home_page' folder does not exist in the repository."
-            echo "HOME_PAGE_EXISTS=false" >> $GITHUB_ENV
-          fi
-
-      - name: Build blueprint and copy to `home_page/blueprint`
-        uses: xu-cheng/texlive-action@v2
+      - name: Build project documentation.
+        id: build-docgen
+        uses: leanprover-community/docgen-action@main
         with:
-          docker_image: ghcr.io/xu-cheng/texlive-full:20231201
-          run: |
-            # Install necessary dependencies and build the blueprint
-            apk update
-            apk add --update make py3-pip git pkgconfig graphviz graphviz-dev gcc musl-dev
-            git config --global --add safe.directory $GITHUB_WORKSPACE
-            git config --global --add safe.directory `pwd`
-            python3 -m venv env
-            source env/bin/activate
-            pip install --upgrade pip requests wheel
-            pip install pygraphviz --global-option=build_ext --global-option="-L/usr/lib/graphviz/" --global-option="-R/usr/lib/graphviz/"
-            pip install leanblueprint
-            leanblueprint pdf
-            mkdir -p home_page
-            cp blueprint/print/print.pdf home_page/blueprint.pdf
-            leanblueprint web
-            cp -r blueprint/web home_page/blueprint
-
-      - name: Check declarations mentioned in the blueprint exist in Lean code
-        run: |
-            ~/.elan/bin/lake exe checkdecls blueprint/lean_decls
-
-      - name: Copy API documentation to `home_page/docs`
-        run: cp -r .lake/build/doc home_page/docs
-
-      # - name: Remove unnecessary lake files from documentation in `home_page/docs`
-      #   run: |
-      #     find home_page/docs -name "*.trace" -delete
-      #     find home_page/docs -name "*.hash" -delete
-
-      - name: Bundle dependencies
-        if: github.event_name == 'push'
-        uses: ruby/setup-ruby@v1
-        with:
-          working-directory: home_page
-          ruby-version: "3.0"  # Specify Ruby version
-          bundler-cache: true  # Enable caching for bundler
-
-      - name: Build website using Jekyll
-        if: github.event_name == 'push' && env.HOME_PAGE_EXISTS == 'true'
-        working-directory: home_page
-        run: JEKYLL_ENV=production bundle exec jekyll build  # Note this will also copy the blueprint and API doc into home_page/_site
-
-      - name: "Upload website (API documentation, blueprint and any home page)"
-        if: github.event_name == 'push'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ${{ env.HOME_PAGE_EXISTS == 'true' && 'home_page/_site' || 'home_page/' }}
-
-      - name: Deploy to GitHub Pages
-        if: github.event_name == 'push'
-        id: deployment
-        uses: actions/deploy-pages@v4
+          blueprint: true
+          homepage: home_page

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build project documentation.
         id: build-docgen
-        uses: leanprover-community/docgen-action@main
+        uses: leanprover-community/docgen-action@b210116d3e6096c0c7146f7a96a6d56b6884fef5 # 2025-06-12
         with:
           blueprint: true
           homepage: home_page


### PR DESCRIPTION
This PR replaces the docgen and blueprint steps of the workflow with [a single doc-gen action](https://github.com/leanprover-community/docgen-action). This should help in making the CI steps more consistent and easy to maintain across downstream projects. From the outside, everything should function exactly the same as before. Please see https://vierkantor.github.io/infinity-cosmos for a test build of the site.