### PR TITLE
ci: Bump update action.

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Run the action
         id: check-for-updates
-        uses: leanprover-community/mathlib-update-action@e91d07ac5a7ce1980d200a591d2123449131496b # 2025-06-09
+        uses: leanprover-community/mathlib-update-action@30121004826adb85f006e31ce5d25a33ce79c7a6 # 2025-06-16
         with:
           # START CONFIGURATION BLOCK 1
           legacy_update: true
@@ -25,7 +25,7 @@ jobs:
       issues: write        # Grants permission to create or update issues
       pull-requests: write # Grants permission to create or update pull requests
     needs: check-for-updates
-    if: ${{ needs.check-for-updates.outputs.is-update-available }}
+    if: ${{ needs.check-for-updates.outputs.is-update-available == 'true' }}
     strategy: # Runs for each update discovered by the `check-for-updates` job.
       max-parallel: 1 # Ensures that the PRs/issues are created in order.
       matrix:
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Run the action
         id: update-the-repo
-        uses: leanprover-community/mathlib-update-action/do-update@e91d07ac5a7ce1980d200a591d2123449131496b # 2025-06-09
+        uses: leanprover-community/mathlib-update-action/do-update@30121004826adb85f006e31ce5d25a33ce79c7a6 # 2025-06-16
         with:
           tag: ${{ matrix.tag }}
           # START CONFIGURATION BLOCK 2


### PR DESCRIPTION
This new version does not error if no upgrades exist, and has a 'stable' option for skipping prereleases and Mathlib `master` commits.

Tested on https://github.com/Vierkantor/lean-update-tester.