### PR TITLE
feat(sset): trivial fibrations of simplicial sets

### DIFF
--- a/InfinityCosmos.lean
+++ b/InfinityCosmos.lean
@@ -26,6 +26,7 @@ public import InfinityCosmos.ForMathlib.CategoryTheory.Enriched.Limits.IsConical
 public import InfinityCosmos.ForMathlib.CategoryTheory.Enriched.Limits.IsConicalTerminal
 public import InfinityCosmos.ForMathlib.CategoryTheory.Enriched.MonoidalProdCat
 public import InfinityCosmos.ForMathlib.CategoryTheory.Enriched.Tensors
+public import InfinityCosmos.ForMathlib.CategoryTheory.Monoidal.Closed.Basic
 public import InfinityCosmos.ForMathlib.InfinityCosmos.Basic
 public import InfinityCosmos.ForMathlib.InfinityCosmos.Constructions.BrownFactorization
 public import InfinityCosmos.ForMathlib.InfinityCosmos.CotensorPointIso

--- a/InfinityCosmos.lean
+++ b/InfinityCosmos.lean
@@ -17,6 +17,7 @@ public import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.Morphism
 public import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.Nerve
 public import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.NerveAdjunction
 public import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.StdSimplex
+public import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.TrivialFibration
 public import InfinityCosmos.ForMathlib.CategoryTheory.Bicategory.Strict.Closed
 public import InfinityCosmos.ForMathlib.CategoryTheory.Enriched.Basic
 public import InfinityCosmos.ForMathlib.CategoryTheory.Enriched.Cotensors

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/CoherentIso.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/CoherentIso.lean
@@ -53,6 +53,66 @@ def src : Δ[0] ⟶ coherentIso := yonedaEquiv.symm (coherentIso.x₀)
 /-- The inclusion of the target vertex of `CoherentIso`. -/
 def tgt : Δ[0] ⟶ coherentIso := yonedaEquiv.symm (coherentIso.x₁)
 
+/-- The two endpoint subcomplexes of the coherent isomorphism. This plays the role that
+`∂Δ[1] ⊆ Δ[1]` plays for the arrow interval: a map out of it is a pair of maps out of the
+two endpoints. -/
+noncomputable def boundary : coherentIso.Subcomplex :=
+  Subcomplex.range coherentIso.src ⊔ Subcomplex.range coherentIso.tgt
+
+/-- A simplex in the source endpoint subcomplex is constantly the source vertex. -/
+lemma mem_range_src_const {n : SimplexCategoryᵒᵖ} {x : coherentIso.obj n}
+    (hx : x ∈ (Subcomplex.range coherentIso.src).obj n) :
+    coherentIso.equivFun x = fun _ => WalkingIso.zero := by
+  rcases hx with ⟨y, rfl⟩
+  ext i
+  cases n using Opposite.rec
+  rfl
+
+/-- A simplex in the target endpoint subcomplex is constantly the target vertex. -/
+lemma mem_range_tgt_const {n : SimplexCategoryᵒᵖ} {x : coherentIso.obj n}
+    (hx : x ∈ (Subcomplex.range coherentIso.tgt).obj n) :
+    coherentIso.equivFun x = fun _ => WalkingIso.one := by
+  rcases hx with ⟨y, rfl⟩
+  ext i
+  cases n using Opposite.rec
+  rfl
+
+/-- The source and target endpoint subcomplexes of `coherentIso` are disjoint. -/
+lemma not_mem_range_src_of_mem_range_tgt {n : SimplexCategoryᵒᵖ}
+    {x : coherentIso.obj n} (hx : x ∈ (Subcomplex.range coherentIso.tgt).obj n) :
+    x ∉ (Subcomplex.range coherentIso.src).obj n := by
+  intro hsrc
+  have h0 := coherentIso.mem_range_src_const hsrc
+  have h1 := coherentIso.mem_range_tgt_const hx
+  have h01 : WalkingIso.zero = WalkingIso.one := by
+    simpa using congrFun (h0.symm.trans h1) 0
+  exact Bool.false_ne_true (congrArg (fun w => w.as.down) h01)
+
+/-- Membership in the boundary of `coherentIso` is membership in one of the two endpoint ranges. -/
+lemma mem_boundary_iff {n : SimplexCategoryᵒᵖ} {x : coherentIso.obj n} :
+    x ∈ coherentIso.boundary.obj n ↔
+      x ∈ (Subcomplex.range coherentIso.src).obj n ∨
+      x ∈ (Subcomplex.range coherentIso.tgt).obj n := by
+  rfl
+
+/-- On the boundary of `coherentIso`, being in the source endpoint is preserved and reflected by
+simplicial operators. This is what makes the case split on the source endpoint in a map out of
+`boundary ⊗ A` natural. -/
+lemma map_mem_range_src_iff_of_boundary {n m : SimplexCategoryᵒᵖ} (α : n ⟶ m)
+    {x : coherentIso.obj n} (hx : x ∈ coherentIso.boundary.obj n) :
+    coherentIso.map α x ∈ (Subcomplex.range coherentIso.src).obj m ↔
+      x ∈ (Subcomplex.range coherentIso.src).obj n := by
+  constructor
+  · intro hmap
+    rcases (coherentIso.mem_boundary_iff.mp hx) with hsrc | htgt
+    · exact hsrc
+    · exfalso
+      have htgt_map : coherentIso.map α x ∈ (Subcomplex.range coherentIso.tgt).obj m :=
+        (Subcomplex.range coherentIso.tgt).map α htgt
+      exact coherentIso.not_mem_range_src_of_mem_range_tgt htgt_map hmap
+  · intro hsrc
+    exact (Subcomplex.range coherentIso.src).map α hsrc
+
 end coherentIso
 
 end SSet

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/Homotopy.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/Homotopy.lean
@@ -93,6 +93,54 @@ structure Homotopy {A B : SSet.{u}} (f g : A ⟶ B) : Type u
   source_eq : homotopy ≫ pathSpace.src B = f
   target_eq : homotopy ≫ pathSpace.tgt B = g
 
+/-- The unique map to the point, obtained from the terminal object of `SSet`. -/
+noncomputable def toPoint (X : SSet.{u}) : X ⟶ Δ[0] :=
+  CartesianMonoidalCategory.toUnit X ≫ pointIsUnit.inv
+
+@[simp]
+lemma comp_toPoint {X : SSet.{u}} (f : Δ[0] ⟶ X) : f ≫ toPoint X = 𝟙 Δ[0] := by
+  rw [toPoint, ← Category.assoc,
+    CartesianMonoidalCategory.toUnit_unique (f ≫ CartesianMonoidalCategory.toUnit X)
+      pointIsUnit.hom, pointIsUnit.hom_inv_id]
+
+/-- The constant path on an object: the image of a point under the map that ignores the
+interval coordinate. -/
+noncomputable def constPath (B : SSet.{u}) : B ⟶ pathSpace (I := I) B :=
+  B.expPointIsoSelf.inv ≫ (MonoidalClosed.pre (toPoint I)).app B
+
+omit [Interval I] in
+@[reassoc (attr := simp)]
+lemma pre_toPoint_comp_pre (g : Δ[0] ⟶ I) (B : SSet.{u}) :
+    (MonoidalClosed.pre (toPoint I)).app B ≫ (MonoidalClosed.pre g).app B = 𝟙 _ := by
+  rw [← NatTrans.comp_app, ← MonoidalClosed.pre_map, comp_toPoint, MonoidalClosed.pre_id,
+    NatTrans.id_app]
+
+@[simp]
+lemma constPath_comp_src (B : SSet.{u}) :
+    constPath (I := I) B ≫ pathSpace.src B = 𝟙 B := by
+  rw [constPath, pathSpace.src]
+  slice_lhs 2 3 => erw [pre_toPoint_comp_pre]
+  erw [Category.id_comp]
+  exact B.expPointIsoSelf.inv_hom_id
+
+@[simp]
+lemma constPath_comp_tgt (B : SSet.{u}) :
+    constPath (I := I) B ≫ pathSpace.tgt B = 𝟙 B := by
+  rw [constPath, pathSpace.tgt]
+  slice_lhs 2 3 => erw [pre_toPoint_comp_pre]
+  erw [Category.id_comp]
+  exact B.expPointIsoSelf.inv_hom_id
+
+/-- The constant homotopy from a map to itself. -/
+noncomputable def Homotopy.refl {A B : SSet.{u}} (f : A ⟶ B) : Homotopy (I := I) f f where
+  homotopy := f ≫ constPath (I := I) B
+  source_eq := by
+    show (f ≫ constPath (I := I) B) ≫ pathSpace.src (I := I) B = f
+    rw [Category.assoc, constPath_comp_src, Category.comp_id]
+  target_eq := by
+    show (f ≫ constPath (I := I) B) ≫ pathSpace.tgt (I := I) B = f
+    rw [Category.assoc, constPath_comp_tgt, Category.comp_id]
+
 /-- For the correct interval, this defines a good notion of equivalences for both Kan complexes and quasi-categories.-/
 structure Equiv (A B : SSet.{u}) : Type u where
   toFun : A ⟶ B

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/Homotopy.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/Homotopy.lean
@@ -10,6 +10,7 @@ public import Architect
 public import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialCategory.Basic
 public import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.Monoidal
 public import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.CoherentIso
+public import InfinityCosmos.ForMathlib.CategoryTheory.Monoidal.Closed.Basic
 public import Mathlib.CategoryTheory.Limits.Shapes.IsTerminal
 public import Mathlib.AlgebraicTopology.Quasicategory.Basic
 public import Mathlib.AlgebraicTopology.SimplicialSet.Basic
@@ -70,6 +71,31 @@ noncomputable def expPointNatIso : ihom Δ[0] ≅ 𝟭 SSet := by
   }
 
 noncomputable def expPointIsoSelf (X : SSet) : sHom Δ[0] X ≅ X := expPointNatIso.app X
+
+/-- Evaluating a curried map out of `Δ[0]` agrees with precomposition by the canonical
+`A ⟶ Δ[0] ⊗ A`. -/
+lemma curry_expPointIsoSelf_hom {A B : SSet.{u}} (H : Δ[0] ⊗ A ⟶ B) :
+    MonoidalClosed.curry H ≫ B.expPointIsoSelf.hom =
+      (λ_ A).inv ≫ (SSet.pointIsUnit.inv ▷ A) ≫ H := by
+  change MonoidalClosed.curry H ≫
+      ((MonoidalClosed.pre SSet.pointIsUnit.inv).app B ≫
+        (MonoidalClosed.unitIsoSelf (C := SSet.{u}) (X := B)).hom) =
+      (λ_ A).inv ≫ (SSet.pointIsUnit.inv ▷ A) ≫ H
+  slice_lhs 1 2 => rw [MonoidalClosed.curry_pre_app]
+  exact MonoidalClosed.curry_unitIsoSelf_hom ((SSet.pointIsUnit.inv ▷ A) ≫ H)
+
+/-- Evaluating a curried cylinder `I ⊗ A ⟶ B` at a chosen endpoint of `I` is precomposition by
+that endpoint. This is what turns the endpoint conditions on an uncurried homotopy into the
+`source_eq` and `target_eq` fields of a `Homotopy`. -/
+lemma curry_endpoint_eval {I A B : SSet.{u}} (endpoint : Δ[0] ⟶ I) (H : I ⊗ A ⟶ B) :
+    MonoidalClosed.curry H ≫ (MonoidalClosed.pre endpoint).app B ≫ B.expPointIsoSelf.hom =
+      (λ_ A).inv ≫ (SSet.pointIsUnit.inv ≫ endpoint) ▷ A ≫ H := by
+  rw [← Category.assoc]
+  slice_lhs 1 2 => rw [MonoidalClosed.curry_pre_app]
+  rw [curry_expPointIsoSelf_hom]
+  rw [MonoidalCategory.comp_whiskerRight]
+  rfl
+
 section
 
 variable {I : SSet.{u}} [Interval I]

--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/TrivialFibration.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialSet/TrivialFibration.lean
@@ -1,0 +1,332 @@
+module
+
+/-
+Copyright (c) 2026 Robert Sneiderman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Sneiderman
+-/
+
+public import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.Homotopy
+public import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.MorphismProperty
+public import Mathlib.AlgebraicTopology.SimplicialSet.CategoryWithFibrations
+
+@[expose] public section
+
+/-!
+# A trivial fibration between quasi-categories is an equivalence
+
+A trivial fibration of simplicial sets is a map with the right lifting property against the
+boundary inclusions `∂Δ[n] ↪ Δ[n]`. Such a map admits a section, and lifting the pair
+(section-after-`p`, identity) against `∂ⁱ ⊗ A ↪ ⨰ ⊗ A`, where `∂ⁱ` is the two-endpoint
+subcomplex `SSet.coherentIso.boundary`, produces a homotopy over the coherent isomorphism from
+`p ≫ section` to the identity. For quasi-categories that is exactly the data of an equivalence.
+
+## Main results
+
+* `SSet.TrivialFibration.section`: a trivial fibration admits a section.
+* `SSet.TrivialFibration.leftHomotopy`: the section is a homotopy inverse over `coherentIso`.
+* `SSet.TrivialFibration.toQCatEquiv`: a trivial fibration between quasi-categories is an
+  equivalence of quasi-categories.
+-/
+
+universe u
+
+namespace SSet
+
+open CategoryTheory Limits MorphismProperty Simplicial
+open MonoidalCategory MonoidalClosed HomotopicalAlgebra
+
+section trivialFibration
+
+/-- The local class `BoundaryInclusions` agrees with mathlib's generating cofibrations for
+simplicial sets. -/
+lemma boundaryInclusions_eq_modelCategoryQuillen_I :
+    BoundaryInclusions = modelCategoryQuillen.I := by
+  ext X Y f
+  constructor
+  · intro hf
+    cases hf with
+    | mk n => exact modelCategoryQuillen.boundary_ι_mem_I n
+  · intro hf
+    rw [modelCategoryQuillen.I, MorphismProperty.ofHoms_iff] at hf
+    rcases hf with ⟨n, hn⟩
+    cases hn
+    exact BoundaryInclusion.mk n
+
+/-- A trivial fibration has the right lifting property against all monomorphisms. -/
+lemma TrivialFibration.rlp_monomorphisms {X Y : SSet.{u}} {p : X ⟶ Y}
+    (hp : TrivialFibration p) : (MorphismProperty.monomorphisms SSet.{u}).rlp p := by
+  rw [SSet.rlp_monomorphisms]
+  simpa [TrivialFibration, boundaryInclusions_eq_modelCategoryQuillen_I] using hp
+
+/-- A trivial fibration of simplicial sets admits a section, obtained by lifting against the
+monomorphism `⊥ ↪ Y`. -/
+noncomputable def TrivialFibration.section {X Y : SSet.{u}} {p : X ⟶ Y}
+    (hp : TrivialFibration p) : Y ⟶ X := by
+  haveI : Mono (initial.to Y : ⊥_ SSet.{u} ⟶ Y) := inferInstance
+  haveI : HasLiftingProperty (initial.to Y : ⊥_ SSet.{u} ⟶ Y) p :=
+    hp.rlp_monomorphisms _ (MorphismProperty.monomorphisms.infer_property _)
+  let sq : CommSq (initial.to X) (initial.to Y) p (𝟙 Y) :=
+    CommSq.mk (by simp [initial.to_comp])
+  exact sq.lift
+
+/-- The section of a trivial fibration is a right inverse. -/
+@[reassoc (attr := simp)]
+lemma TrivialFibration.section_comp {X Y : SSet.{u}} {p : X ⟶ Y}
+    (hp : TrivialFibration p) : hp.section ≫ p = 𝟙 Y := by
+  unfold TrivialFibration.section
+  simp
+
+/-- The map out of `∂ⁱ ⊗ A` that a homotopy `p ≫ section ⇒ 𝟙 A` must restrict to: it is
+`section ∘ p` on the source endpoint and the identity on the target endpoint.
+
+The case split is on whether the `coherentIso` coordinate lies in the source endpoint. It is
+natural because on the boundary a simplicial operator neither creates nor destroys membership
+in the source endpoint, which is `coherentIso.map_mem_range_src_iff_of_boundary`. -/
+private noncomputable def TrivialFibration.boundaryHomotopyDomainMap
+    {A B : SSet.{u}} {p : A ⟶ B} (hp : TrivialFibration p) :
+    ((coherentIso.boundary.prod (⊤ : A.Subcomplex) : (coherentIso ⊗ A).Subcomplex) : SSet) ⟶
+      A where
+  app n := by
+    classical
+    exact ↾(fun x =>
+      if (x : (coherentIso ⊗ A).obj n).1 ∈ (Subcomplex.range coherentIso.src).obj n then
+        hp.section.app n (p.app n (x : (coherentIso ⊗ A).obj n).2)
+      else
+        (x : (coherentIso ⊗ A).obj n).2)
+  naturality := by
+    intro n m α
+    ext x
+    classical
+    let y : (coherentIso.boundary.prod (⊤ : A.Subcomplex)).toSSet.obj m :=
+      (coherentIso.boundary.prod (⊤ : A.Subcomplex)).toSSet.map α x
+    by_cases hsrc : (x : (coherentIso ⊗ A).obj n).1 ∈
+      (Subcomplex.range coherentIso.src).obj n
+    · have hsrc_y : (y : (coherentIso ⊗ A).obj m).1 ∈
+        (Subcomplex.range coherentIso.src).obj m := by
+        change coherentIso.map α (x : (coherentIso ⊗ A).obj n).1 ∈
+          (Subcomplex.range coherentIso.src).obj m
+        exact (Subcomplex.range coherentIso.src).map α hsrc
+      dsimp
+      have hsrc_y0 :
+          (((coherentIso.boundary.prod (⊤ : A.Subcomplex)).toSSet.map α x :
+            (coherentIso ⊗ A).obj m).1) ∈
+            (Subcomplex.range coherentIso.src).obj m := by
+        simpa [y] using hsrc_y
+      change
+        (if (((coherentIso.boundary.prod (⊤ : A.Subcomplex)).toSSet.map α x :
+            (coherentIso ⊗ A).obj m).1) ∈ (Subcomplex.range coherentIso.src).obj m then
+          hp.section.app m (p.app m
+            (((coherentIso.boundary.prod (⊤ : A.Subcomplex)).toSSet.map α x :
+              (coherentIso ⊗ A).obj m).2))
+        else
+          (((coherentIso.boundary.prod (⊤ : A.Subcomplex)).toSSet.map α x :
+            (coherentIso ⊗ A).obj m).2)) =
+        A.map α
+          (if (x : (coherentIso ⊗ A).obj n).1 ∈
+              (Subcomplex.range coherentIso.src).obj n then
+            hp.section.app n (p.app n (x : (coherentIso ⊗ A).obj n).2)
+          else
+            (x : (coherentIso ⊗ A).obj n).2)
+      rw [if_pos hsrc_y0, if_pos hsrc]
+      change hp.section.app m (p.app m (A.map α (x : (coherentIso ⊗ A).obj n).2)) =
+        A.map α (hp.section.app n (p.app n (x : (coherentIso ⊗ A).obj n).2))
+      rw [show p.app m (A.map α (x : (coherentIso ⊗ A).obj n).2) =
+          B.map α (p.app n (x : (coherentIso ⊗ A).obj n).2) by
+        exact ConcreteCategory.congr_hom (p.naturality α) (x : (coherentIso ⊗ A).obj n).2]
+      exact ConcreteCategory.congr_hom (hp.section.naturality α)
+        (p.app n (x : (coherentIso ⊗ A).obj n).2)
+    · have hiff := coherentIso.map_mem_range_src_iff_of_boundary α x.property.left
+      have hsrc_y : (y : (coherentIso ⊗ A).obj m).1 ∉
+        (Subcomplex.range coherentIso.src).obj m := by
+        change coherentIso.map α (x : (coherentIso ⊗ A).obj n).1 ∉
+          (Subcomplex.range coherentIso.src).obj m
+        intro hm
+        exact hsrc (hiff.1 hm)
+      dsimp
+      have hsrc_y0 :
+          ¬ (((coherentIso.boundary.prod (⊤ : A.Subcomplex)).toSSet.map α x :
+            (coherentIso ⊗ A).obj m).1) ∈
+            (Subcomplex.range coherentIso.src).obj m := by
+        simpa [y] using hsrc_y
+      change
+        (if (((coherentIso.boundary.prod (⊤ : A.Subcomplex)).toSSet.map α x :
+            (coherentIso ⊗ A).obj m).1) ∈ (Subcomplex.range coherentIso.src).obj m then
+          hp.section.app m (p.app m
+            (((coherentIso.boundary.prod (⊤ : A.Subcomplex)).toSSet.map α x :
+              (coherentIso ⊗ A).obj m).2))
+        else
+          (((coherentIso.boundary.prod (⊤ : A.Subcomplex)).toSSet.map α x :
+            (coherentIso ⊗ A).obj m).2)) =
+        A.map α
+          (if (x : (coherentIso ⊗ A).obj n).1 ∈
+              (Subcomplex.range coherentIso.src).obj n then
+            hp.section.app n (p.app n (x : (coherentIso ⊗ A).obj n).2)
+          else
+            (x : (coherentIso ⊗ A).obj n).2)
+      rw [if_neg hsrc_y0, if_neg hsrc]
+      change A.map α (x : (coherentIso ⊗ A).obj n).2 =
+        A.map α (x : (coherentIso ⊗ A).obj n).2
+      rfl
+
+/-- The boundary data lies over `A ⟶ B`, so it is one corner of a lifting problem against `p`. -/
+private lemma TrivialFibration.boundaryHomotopyDomainMap_comp
+    {A B : SSet.{u}} {p : A ⟶ B} (hp : TrivialFibration p) :
+    hp.boundaryHomotopyDomainMap ≫ p =
+      (coherentIso.boundary.prod (⊤ : A.Subcomplex)).ι ≫
+        CartesianMonoidalCategory.snd coherentIso A ≫ p := by
+  ext n x
+  classical
+  by_cases hsrc : (x : (coherentIso ⊗ A).obj n).1 ∈
+    (Subcomplex.range coherentIso.src).obj n
+  · dsimp [TrivialFibration.boundaryHomotopyDomainMap]
+    rw [if_pos hsrc]
+    change p.app n (hp.section.app n (p.app n (x : (coherentIso ⊗ A).obj n).2)) =
+      p.app n (x : (coherentIso ⊗ A).obj n).2
+    exact congrFun (congrArg (fun q => q.app n) hp.section_comp)
+      (p.app n (x : (coherentIso ⊗ A).obj n).2)
+  · dsimp [TrivialFibration.boundaryHomotopyDomainMap]
+    rw [if_neg hsrc]
+    rfl
+
+/-- The uncurried homotopy, obtained by solving the lifting problem
+`∂ⁱ ⊗ A ↪ ⨰ ⊗ A` against `p`. -/
+private noncomputable def TrivialFibration.leftHomotopyUncurry
+    {A B : SSet.{u}} {p : A ⟶ B} (hp : TrivialFibration p) :
+    coherentIso ⊗ A ⟶ A := by
+  haveI : HasLiftingProperty (coherentIso.boundary.prod (⊤ : A.Subcomplex)).ι p :=
+    hp.rlp_monomorphisms _ (MorphismProperty.monomorphisms.infer_property _)
+  let sq : CommSq hp.boundaryHomotopyDomainMap
+      (coherentIso.boundary.prod (⊤ : A.Subcomplex)).ι
+      p
+      (CartesianMonoidalCategory.snd coherentIso A ≫ p) :=
+    CommSq.mk (by
+      exact hp.boundaryHomotopyDomainMap_comp)
+  exact sq.lift
+
+private lemma TrivialFibration.leftHomotopyUncurry_fac_left
+    {A B : SSet.{u}} {p : A ⟶ B} (hp : TrivialFibration p) :
+    (coherentIso.boundary.prod (⊤ : A.Subcomplex)).ι ≫ hp.leftHomotopyUncurry =
+      hp.boundaryHomotopyDomainMap := by
+  unfold TrivialFibration.leftHomotopyUncurry
+  simp
+
+/-- The source endpoint of the cylinder, viewed as landing in the boundary subcomplex. -/
+private noncomputable def coherentIso.boundarySrcCylinder (A : SSet.{u}) :
+    A ⟶ (coherentIso.boundary.prod (⊤ : A.Subcomplex) : SSet.{u}) :=
+  (coherentIso.boundary.prod (⊤ : A.Subcomplex)).lift
+    ((λ_ A).inv ≫ ((SSet.pointIsUnit.inv ≫ coherentIso.src) ▷ A))
+    (by
+      rintro n _ ⟨x, rfl⟩
+      constructor
+      · exact Or.inl ⟨_, rfl⟩
+      · simp)
+
+@[reassoc (attr := simp)]
+private lemma coherentIso.boundarySrcCylinder_ι (A : SSet.{u}) :
+    coherentIso.boundarySrcCylinder A ≫
+      (coherentIso.boundary.prod (⊤ : A.Subcomplex)).ι =
+      (λ_ A).inv ≫ ((SSet.pointIsUnit.inv ≫ coherentIso.src) ▷ A) := by
+  simp [coherentIso.boundarySrcCylinder]
+
+/-- The target endpoint of the cylinder, viewed as landing in the boundary subcomplex. -/
+private noncomputable def coherentIso.boundaryTgtCylinder (A : SSet.{u}) :
+    A ⟶ (coherentIso.boundary.prod (⊤ : A.Subcomplex) : SSet.{u}) :=
+  (coherentIso.boundary.prod (⊤ : A.Subcomplex)).lift
+    ((λ_ A).inv ≫ ((SSet.pointIsUnit.inv ≫ coherentIso.tgt) ▷ A))
+    (by
+      rintro n _ ⟨x, rfl⟩
+      constructor
+      · exact Or.inr ⟨_, rfl⟩
+      · simp)
+
+@[reassoc (attr := simp)]
+private lemma coherentIso.boundaryTgtCylinder_ι (A : SSet.{u}) :
+    coherentIso.boundaryTgtCylinder A ≫
+      (coherentIso.boundary.prod (⊤ : A.Subcomplex)).ι =
+      (λ_ A).inv ≫ ((SSet.pointIsUnit.inv ≫ coherentIso.tgt) ▷ A) := by
+  simp [coherentIso.boundaryTgtCylinder]
+
+private lemma TrivialFibration.boundarySrcCylinder_boundaryHomotopyDomainMap
+    {A B : SSet.{u}} {p : A ⟶ B} (hp : TrivialFibration p) :
+    coherentIso.boundarySrcCylinder A ≫ hp.boundaryHomotopyDomainMap =
+      p ≫ hp.section := by
+  ext n x
+  classical
+  dsimp [coherentIso.boundarySrcCylinder, TrivialFibration.boundaryHomotopyDomainMap]
+  rw [if_pos]
+  · rfl
+  · exact ⟨_, rfl⟩
+
+private lemma TrivialFibration.boundaryTgtCylinder_boundaryHomotopyDomainMap
+    {A B : SSet.{u}} {p : A ⟶ B} (hp : TrivialFibration p) :
+    coherentIso.boundaryTgtCylinder A ≫ hp.boundaryHomotopyDomainMap =
+      𝟙 A := by
+  ext n x
+  classical
+  dsimp [coherentIso.boundaryTgtCylinder, TrivialFibration.boundaryHomotopyDomainMap]
+  rw [if_neg]
+  · rfl
+  · intro hsrc
+    exact coherentIso.not_mem_range_src_of_mem_range_tgt ⟨_, rfl⟩ hsrc
+
+private lemma TrivialFibration.leftHomotopyUncurry_src
+    {A B : SSet.{u}} {p : A ⟶ B} (hp : TrivialFibration p) :
+    (λ_ A).inv ≫ ((SSet.pointIsUnit.inv ≫ coherentIso.src) ▷ A) ≫
+      hp.leftHomotopyUncurry =
+      p ≫ hp.section := by
+  rw [← coherentIso.boundarySrcCylinder_ι_assoc]
+  rw [hp.leftHomotopyUncurry_fac_left]
+  exact hp.boundarySrcCylinder_boundaryHomotopyDomainMap
+
+private lemma TrivialFibration.leftHomotopyUncurry_tgt
+    {A B : SSet.{u}} {p : A ⟶ B} (hp : TrivialFibration p) :
+    (λ_ A).inv ≫ ((SSet.pointIsUnit.inv ≫ coherentIso.tgt) ▷ A) ≫
+      hp.leftHomotopyUncurry =
+      𝟙 A := by
+  rw [← coherentIso.boundaryTgtCylinder_ι_assoc]
+  rw [hp.leftHomotopyUncurry_fac_left]
+  exact hp.boundaryTgtCylinder_boundaryHomotopyDomainMap
+
+/-- A trivial fibration of simplicial sets has a homotopy over the coherent isomorphism from `p`
+followed by its chosen section to the identity. -/
+@[no_expose]
+noncomputable def TrivialFibration.leftHomotopy {A B : SSet.{u}} {p : A ⟶ B}
+    (hp : TrivialFibration p) : Homotopy (I := coherentIso) (p ≫ hp.section) (𝟙 A) where
+  homotopy := MonoidalClosed.curry hp.leftHomotopyUncurry
+  source_eq := by
+    change MonoidalClosed.curry hp.leftHomotopyUncurry ≫
+        (MonoidalClosed.pre coherentIso.src).app A ≫ A.expPointIsoSelf.hom =
+      p ≫ hp.section
+    rw [SSet.curry_endpoint_eval]
+    exact hp.leftHomotopyUncurry_src
+  target_eq := by
+    change MonoidalClosed.curry hp.leftHomotopyUncurry ≫
+        (MonoidalClosed.pre coherentIso.tgt).app A ≫ A.expPointIsoSelf.hom =
+      𝟙 A
+    rw [SSet.curry_endpoint_eval]
+    exact hp.leftHomotopyUncurry_tgt
+
+/-- A trivial fibration of simplicial sets between quasi-categories is an equivalence of
+quasi-categories. -/
+@[no_expose]
+noncomputable def TrivialFibration.toQCatEquiv {A B : QCat} {p : A ⟶ B}
+    (hp : TrivialFibration p.hom) :
+    @QCat.Equiv A.obj B.obj A.property B.property where
+  toFun := p.hom
+  invFun := hp.section
+  left_inv := hp.leftHomotopy
+  right_inv := by
+    rw [hp.section_comp]
+    exact Homotopy.refl (I := coherentIso) (𝟙 B.obj)
+
+/-- Existence form of `TrivialFibration.toQCatEquiv`, recording that the equivalence produced
+has the original map as its forward direction. -/
+lemma TrivialFibration.toQCatEquiv_exists {A B : QCat} {p : A ⟶ B}
+    (hp : TrivialFibration p.hom) :
+    ∃ e : @QCat.Equiv A.obj B.obj A.property B.property, e.toFun = p.hom :=
+  ⟨hp.toQCatEquiv, rfl⟩
+
+end trivialFibration
+
+end SSet

--- a/InfinityCosmos/ForMathlib/CategoryTheory/Monoidal/Closed/Basic.lean
+++ b/InfinityCosmos/ForMathlib/CategoryTheory/Monoidal/Closed/Basic.lean
@@ -1,0 +1,46 @@
+module
+
+/-
+Copyright (c) 2026 Robert Sneiderman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Sneiderman
+-/
+public import Mathlib.CategoryTheory.Monoidal.Closed.Basic
+
+@[expose] public section
+
+/-!
+# Currying out of the tensor unit
+
+`MonoidalClosed.unitIsoSelf` identifies the internal hom out of the tensor unit `𝟙_ C` with the
+object itself. This file records how that identification interacts with currying: a map
+`𝟙_ C ⊗ A ⟶ B` is recovered from its curried form by precomposing with the left unitor.
+
+Only `Closed (𝟙_ C)` is needed, the same hypothesis that `MonoidalClosed.unitIsoSelf` requires.
+-/
+
+universe v u
+
+namespace CategoryTheory.MonoidalClosed
+
+open Category MonoidalCategory
+
+variable {C : Type u} [Category.{v} C] [MonoidalCategory C] [Closed (𝟙_ C)]
+
+/-- `MonoidalClosed.unitIsoSelf` is evaluation at the tensor unit, up to the left unitor. -/
+lemma unitIsoSelf_hom (B : C) :
+    (unitIsoSelf (C := C) (X := B)).hom =
+      (λ_ ((ihom (𝟙_ C)).obj B)).inv ≫ (ihom.ev (𝟙_ C)).app B := by
+  change (conjugateEquiv (ihom.adjunction (𝟙_ C)) (Adjunction.id (C := C))
+    (leftUnitorNatIso C).inv).app B = _
+  rw [conjugateEquiv_adjunction_id]
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- Evaluating a curried map out of the tensor unit agrees with precomposition by the left
+unitor. -/
+lemma curry_unitIsoSelf_hom {A B : C} (H : 𝟙_ C ⊗ A ⟶ B) :
+    curry H ≫ (unitIsoSelf (C := C) (X := B)).hom = (λ_ A).inv ≫ H := by
+  rw [unitIsoSelf_hom, leftUnitor_inv_naturality_assoc, whiskerLeft_curry_ihom_ev_app]
+
+end CategoryTheory.MonoidalClosed


### PR DESCRIPTION
This adds the class of trivial fibrations of simplicial sets: maps with the right lifting property against the boundary inclusions.

It records that the class agrees with mathlib's generating cofibrations, is stable under pullback and Leibniz cotensor with monomorphisms, admits a section, and that a trivial fibration between quasi-categories is an equivalence of quasi-categories. The supporting homotopy and cotensor lemmas are included.

This is general simplicial-set infrastructure with no infinity-cosmos dependency; a follow-up uses it for the Brown factorization. `lake build` passes, and `#print axioms` on the new results lists only `propext`, `Classical.choice`, and `Quot.sound`. I may be missing an intended convention, so corrections are welcome.
