### PR TITLE
feat(cotensors): naturality of the cotensor comparison isomorphism

### DIFF
--- a/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/Cotensors.lean
+++ b/InfinityCosmos/ForMathlib/AlgebraicTopology/SimplicialCategory/Cotensors.lean
@@ -129,6 +129,13 @@ lemma eHomEquiv_comp_eHomWhiskerRight {X Y Z : K} (f : X ⟶ Y) (g : Y ⟶ Z) :
       (homEquiv' Y Z g) = homEquiv' X Z (f ≫ g)
   rw [homEquiv'_comp]
 
+/-- Enriched composition is natural in its middle variable. -/
+lemma eComp_eHomWhisker_middle {X Y Y' Z : K} (g : Y ⟶ Y') :
+    eHomWhiskerLeft SSet X g ▷ sHom Y' Z ≫ eComp SSet X Y' Z =
+      sHom X Y ◁ eHomWhiskerRight SSet g Z ≫ eComp SSet X Y Z := by
+  dsimp [eHomWhiskerLeft, eHomWhiskerRight]
+  simp [e_assoc]
+
 /-- The identity morphism, transported to zero-simplices of the enriched hom. -/
 lemma homEquiv'_id (X : K) :
     homEquiv' X X (𝟙 X) = ((eId SSet X).app ⟨SimplexCategory.mk 0⟩) PUnit.unit := by
@@ -308,6 +315,101 @@ theorem cotensor_bifunctoriality {U V : SSet} (i : U ⟶ V) {A B : K} (f : A ⟶
     cotensorContraMap i A ≫ cotensorCovMap U f =
       cotensorCovMap V f ≫ cotensorContraMap i B :=
   cotensor_local_bifunctoriality _ _ _ _ i f
+
+
+/-- The chosen cotensor cone is natural with respect to covariant cotensor maps. -/
+lemma cotensorPostcompose_cone {U : SSet.{v}} {A B : K} (f : A ⟶ B) :
+    (getCotensor U B).cone ≫
+      eHomWhiskerRight SSet
+        (cotensorPostcompose (getCotensor U A) (getCotensor U B) f) B =
+        (getCotensor U A).cone ≫
+          eHomWhiskerLeft SSet (getCotensor U A).obj f := by
+  calc
+    (getCotensor U B).cone ≫
+        eHomWhiskerRight SSet
+          (cotensorPostcompose (getCotensor U A) (getCotensor U B) f) B =
+      (λ_ U).inv ≫ ((eHomEquiv SSet) f ▷ U) ≫
+        (Cotensor.postcompose SSet (getCotensor U A) (getCotensor U B) ▷ U) ≫
+        (_ ◁ (getCotensor U B).cone) ≫
+        eComp SSet (getCotensor U A).obj (getCotensor U B).obj B := by
+        dsimp [eHomWhiskerRight]
+        rw [cotensorPostcompose_homEquiv]
+        rw [leftUnitor_inv_naturality_assoc]
+        rw [MonoidalCategory.comp_whiskerRight_assoc]
+        rw [MonoidalCategory.whisker_exchange_assoc]
+        rw [MonoidalCategory.whisker_exchange_assoc]
+    _ = (λ_ U).inv ≫ ((eHomEquiv SSet) f ▷ U) ≫
+        (β_ (A ⟶[SSet] B) U).hom ≫
+        ((getCotensor U A).cone ▷ (A ⟶[SSet] B)) ≫
+        eComp SSet (getCotensor U A).obj A B := by
+        rw [Cotensor.postcompose_selfEval_comp_eq]
+        rfl
+    _ = (getCotensor U A).cone ≫
+        eHomWhiskerLeft SSet (getCotensor U A).obj f := by
+        dsimp [eHomWhiskerLeft]
+        rw [braiding_naturality_left_assoc]
+        rw [braiding_tensorUnit_left_assoc]
+        rw [Iso.inv_hom_id_assoc]
+        rw [MonoidalCategory.whisker_exchange_assoc]
+        rw [← rightUnitor_inv_naturality_assoc]
+
+/-- Naturality of `cotensor.iso` under precomposition in the simplicial-set variable. -/
+lemma cotensor_iso_hom_naturality_precompose {U V : SSet.{v}} (i : U ⟶ V) (A X : K) :
+    eHomWhiskerLeft SSet X (cotensorContraMap i A) ≫ (cotensor.iso U A X).hom =
+      (cotensor.iso V A X).hom ≫ (MonoidalClosed.pre i).app (sHom X A) := by
+  change eHomWhiskerLeft SSet X (cotensorPrecompose (getCotensor U A) (getCotensor V A) i) ≫
+      (getCotensor U A).coneNatTrans X =
+    (getCotensor V A).coneNatTrans X ≫ (MonoidalClosed.pre i).app (sHom X A)
+  apply MonoidalClosed.uncurry_injective
+  rw [MonoidalClosed.uncurry_natural_left]
+  change U ◁ eHomWhiskerLeft SSet X (cotensorPrecompose (getCotensor U A)
+      (getCotensor V A) i) ≫ MonoidalClosed.uncurry ((getCotensor U A).coneNatTrans X) =
+    (i ▷ (X ⟶[SSet] (getCotensor V A).obj)) ≫
+      MonoidalClosed.uncurry ((getCotensor V A).coneNatTrans X)
+  rw [(getCotensor U A).toPrecotensor.coneNatTrans_eq]
+  rw [(getCotensor V A).toPrecotensor.coneNatTrans_eq]
+  rw [braiding_naturality_left_assoc]
+  rw [braiding_naturality_right_assoc]
+  apply (Iso.cancel_iso_hom_left
+    (β_ U (X ⟶[SSet] (getCotensor V A).obj)) _ _).mpr
+  rw [← whisker_exchange_assoc]
+  rw [eComp_eHomWhisker_middle]
+  rw [← MonoidalCategory.whiskerLeft_comp_assoc]
+  change (X ⟶[SSet] (getCotensor V A).obj) ◁
+      ((getCotensor U A).cone ≫ eHomWhiskerRight SSet (cotensorContraMap i A) A) ≫
+    eComp SSet X (getCotensor V A).obj A = _
+  rw [cotensor_contraMap_cone i A]
+  change ((X ⟶[SSet] (getCotensor V A).obj) ◁ i ≫
+      (X ⟶[SSet] (getCotensor V A).obj) ◁ (getCotensor V A).cone) ≫
+    eComp SSet X (getCotensor V A).obj A = _
+  rw [Category.assoc]
+
+set_option backward.isDefEq.respectTransparency false in
+
+/-- Naturality of `cotensor.iso` under postcomposition in the cotensored object. -/
+lemma cotensor_iso_hom_naturality_postcompose {U : SSet.{v}} {A B : K}
+    (f : A ⟶ B) (X : K) :
+    eHomWhiskerLeft SSet X (cotensorCovMap U f) ≫ (cotensor.iso U B X).hom =
+      (cotensor.iso U A X).hom ≫ (ihom U).map (eHomWhiskerLeft SSet X f) := by
+  change eHomWhiskerLeft SSet X
+      (cotensorPostcompose (getCotensor U A) (getCotensor U B) f) ≫
+      (getCotensor U B).coneNatTrans X =
+    (getCotensor U A).coneNatTrans X ≫
+      (ihom U).map (eHomWhiskerLeft SSet X f)
+  apply MonoidalClosed.uncurry_injective
+  rw [MonoidalClosed.uncurry_natural_left]
+  rw [MonoidalClosed.uncurry_natural_right
+    ((getCotensor U A).coneNatTrans X) (eHomWhiskerLeft SSet X f)]
+  rw [(getCotensor U B).toPrecotensor.coneNatTrans_eq]
+  rw [(getCotensor U A).toPrecotensor.coneNatTrans_eq]
+  rw [braiding_naturality_right_assoc]
+  rw [← whisker_exchange_assoc]
+  simp only [Category.assoc]
+  rw [eComp_eHomWhiskerLeft]
+  rw [eComp_eHomWhisker_middle]
+  rw [← MonoidalCategory.whiskerLeft_comp_assoc]
+  rw [cotensorPostcompose_cone f]
+  rw [MonoidalCategory.whiskerLeft_comp_assoc]
 
 end
 

--- a/InfinityCosmos/ForMathlib/InfinityCosmos/Basic.lean
+++ b/InfinityCosmos/ForMathlib/InfinityCosmos/Basic.lean
@@ -2,6 +2,7 @@ import Architect
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialCategory.Cotensors
 import InfinityCosmos.ForMathlib.CategoryTheory.Enriched.Limits.HasConicalTerminal
 import InfinityCosmos.ForMathlib.CategoryTheory.Enriched.Limits.IsConicalTerminal
+import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.Homotopy
 import InfinityCosmos.ForMathlib.AlgebraicTopology.SimplicialSet.MorphismProperty
 import Mathlib.CategoryTheory.Monoidal.Closed.Cartesian
 import Mathlib.CategoryTheory.Enriched.Limits.HasConicalPullbacks
@@ -40,8 +41,43 @@ noncomputable def representableMap (X : K) {A B : K} (f : A ⟶ B) :
     (EnrichedCategory.Hom X A : SSet) ⟶ EnrichedCategory.Hom X B :=
   representableMap' (eHomEquiv SSet f)
 
+/-- Representable maps preserve identity morphisms. -/
+lemma representableMap_id (X A : K) :
+    representableMap X (𝟙 A) = 𝟙 (EnrichedCategory.Hom X A : SSet) := by
+  change eHomWhiskerLeft SSet X (𝟙 A) = 𝟙 (EnrichedCategory.Hom X A : SSet)
+  rw [eHomWhiskerLeft_id]
+
+/-- Representable maps preserve composition. -/
+lemma representableMap_comp {A B C : K} (X : K) (f : A ⟶ B) (g : B ⟶ C) :
+    representableMap X (f ≫ g) = representableMap X f ≫ representableMap X g := by
+  change eHomWhiskerLeft SSet X (f ≫ g) =
+    eHomWhiskerLeft SSet X f ≫ eHomWhiskerLeft SSet X g
+  rw [eHomWhiskerLeft_comp]
+
 noncomputable def toFunMap (X : K) {A B : K} (f : A ⟶ B) : Fun X A ⟶ Fun X B :=
   ObjectProperty.homMk <| representableMap X f
+
+/-- A morphism in a pre-∞-cosmos is an equivalence if every covariant representable sends it
+to an equivalence of quasi-categories. -/
+def Equivalence {A B : K} (f : A ⟶ B) : Prop :=
+  ∀ X : K,
+    ∃ e : @QCat.Equiv (Fun X A).obj (Fun X B).obj (Fun X A).property (Fun X B).property,
+      e.toFun = (toFunMap X f).hom
+
+/-- A morphism in a pre-∞-cosmos is a trivial fibration if it is both an isofibration and an
+equivalence. -/
+def TrivialFibration {A B : K} (f : A ⟶ B) : Prop :=
+  IsIsofibration f ∧ Equivalence f
+
+/-- A trivial fibration is an isofibration. -/
+lemma TrivialFibration.isIsofibration {A B : K} {f : A ⟶ B} (hf : TrivialFibration f) :
+    IsIsofibration f :=
+  hf.1
+
+/-- A trivial fibration is an equivalence. -/
+lemma TrivialFibration.equivalence {A B : K} {f : A ⟶ B} (hf : TrivialFibration f) :
+    Equivalence f :=
+  hf.2
 
 /-- The subtype of isofibrations. Arguments of this type have the form `⟨ f hf ⟩`. -/
 def Isofibration (X Y : K) : Type v := {f : X ⟶ Y // IsIsofibration f}
@@ -130,6 +166,29 @@ example : HasProducts K := inferInstance
 
 /-- An ∞-cosmos has pullbacks. -/
 example {E B A : K} (p : E ↠ B) (f : A ⟶ B) : HasPullback p.1 f := inferInstance
+
+/-! ### The underlying category of an ∞-cosmos
+
+The underlying category `K₀` of an ∞-cosmos `K` (blueprint `defn:underlying-cat-of-cosmos`) has the
+∞-categories of `K` as objects and the `0`-arrows as morphisms, where a `0`-arrow `A ⟶ B` is a
+vertex of the functor space `Fun A B`. Since a simplicial category is formalized as an enriched
+ordinary category, `K` already carries this `1`-category structure: the ambient `Category K`
+instance is, by definition, the underlying category. The equivalence `homEquivFunVertex` records the
+characterization requested in the blueprint, identifying the morphisms of this category with the
+vertices of the functor spaces. -/
+
+/-- The underlying category of an ∞-cosmos `K` is the ambient `1`-category structure on `K`. -/
+example : Category K := inferInstance
+
+/-- A morphism `A ⟶ B` in the underlying category of an ∞-cosmos is the same data as a `0`-arrow:
+a vertex of the functor space `Fun A B`, i.e. a map from the monoidal unit `𝟙_ SSet` into it. -/
+def homEquivFunVertex {A B : K} : (A ⟶ B) ≃ (𝟙_ SSet ⟶ (Fun A B).obj) :=
+  eHomEquiv SSet
+
+/-- Under the identification of morphisms with `0`-arrows, the identity morphism corresponds to the
+enriched identity vertex. -/
+lemma homEquivFunVertex_id (A : K) : homEquivFunVertex (𝟙 A) = eId SSet A :=
+  eHomEquiv_id SSet A
 
 end InfinityCosmos
 


### PR DESCRIPTION
This adds four lemmas about the cotensor comparison isomorphism, and a few basic definitions in the ∞-cosmos file that later work relies on.

In `SimplicialCategory/Cotensors.lean`:

* `eComp_eHomWhisker_middle`, moving a whiskering across enriched composition in the middle variable.
* `cotensorPostcompose_cone`, identifying the cone of a cotensor after postcomposition.
* `cotensor_iso_hom_naturality_precompose` and `cotensor_iso_hom_naturality_postcompose`, naturality of `cotensor.iso` in the simplicial set and in the object.

In `ForMathlib/InfinityCosmos/Basic.lean`: `representableMap_id` and `representableMap_comp`, the definitions of `Equivalence` and `TrivialFibration` with the two immediate consequences of the latter, and `homEquivFunVertex` identifying morphisms with vertices of the functor space.

These are carved out of #191, which is large. They depend on nothing else in that branch.