### PR TITLE
ci: pin jlumbroso/free-disk-space to a release SHA

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -44,7 +44,7 @@ jobs:
     name: Build project
     steps:
       - name: Cleanup to free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           android: true # saves approximately 12 GB

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check whether an incompatibility is reported
         id: fkb
@@ -46,7 +46,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Open or update incompatibility issue
         id: track
         uses: leanprover-community/downstream-reports/.github/actions/track-incompatibility@main


### PR DESCRIPTION
`jlumbroso/free-disk-space@main` is the only floating action reference in the workflows. Every other action is pinned to a commit SHA, so the blueprint build is reproducible apart from this one step, which runs whatever that branch holds at the moment the job starts. Dependabot cannot propose updates for a branch ref either, so the monthly `github-actions` pass skips it.

## The change

```yaml
       - name: Cleanup to free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
```

`54081f1` is the commit behind the `v1.3.1` tag, the latest release of that action.

The two `actions/checkout` references in `update.yml` were already pinned but carried no version comment, unlike the identical pin in `blueprint.yml`. The same `# v7.0.1` comment is added to both, which is the tag `3d3c42e` resolves to. That is a comment change only.

## Action references after this change

| Workflow | Action | Reference |
|---|---|---|
| blueprint.yml | jlumbroso/free-disk-space | `54081f1` (v1.3.1) |
| blueprint.yml | actions/checkout | `3d3c42e` (v7.0.1) |
| blueprint.yml | leanprover/lean-action | `38fbc41` (v1.5.0) |
| blueprint.yml | leanprover-community/docgen-action | `cc833d2` |
| update.yml | actions/checkout | `3d3c42e` (v7.0.1) |
| create-release.yml | leanprover-community/lean-release-tag | `ee8ee74` |

Chosen: pin to the release SHA with a version comment, matching the form the other five references already use, so dependabot rewrites the SHA and the comment together. Alternative: pin to the `v1.3.1` tag, rejected because a tag is mutable and would leave this the one reference in the repository that a force-pushed tag could change under the build.

## What this leaves alone

The `leanprover-community/downstream-reports` and `leanprover-community/intentions` references in `update.yml` and `intentions.yml` also float, on `@main` and `@v1`. Those are first-party Lean community actions whose authors expect downstream projects to follow the branch, so pinning them would freeze the bump machinery against upstream fixes. They are deliberately untouched here.

## Checks run

Both edited files parse. No workflow behaviour changes: `main` on that action resolves to `54081f1` today, the same commit as `v1.3.1`, so the disk cleanup step runs the code it ran before this pin and the blueprint build is unaffected.
