### PR TITLE
ci: make the style lint check out the repository

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,9 @@ jobs:
   style_lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Check for long lines
         if: always() # Ensure the step runs regardless of the success or failure of previous steps
         run: |
@@ -27,4 +30,5 @@ jobs:
         if: always() # Ensure the step runs regardless of the success or failure of previous steps
         run: |
           # Find and disallow any file that imports the entire Mathlib, encouraging precise imports instead
-          ! (find InfinityCosmos -name "*.lean" -type f -print0 | xargs -0 grep -E -n '^import Mathlib$')
+          # The module system allows import modifiers, so 'public import Mathlib' and 'import all Mathlib' count too
+          ! (find InfinityCosmos -name "*.lean" -type f -print0 | xargs -0 grep -E -n '^(public |private |protected |meta )*import (all )?Mathlib$')


### PR DESCRIPTION
Both steps in `lint.yml` run `find InfinityCosmos ...`, but the job never checks out the repository. `find` reports a missing directory and exits 1, the leading `!` inverts that, and the step passes. Neither check has ever read a file.

Run on a fork at 8c1b085, the workflow reports success in under a second, with this in the log:

```
style_lint  Check for long lines                              find: 'InfinityCosmos': No such file or directory
style_lint  Don't 'import Mathlib', use precise imports        find: 'InfinityCosmos': No such file or directory
```

## The two changes

A checkout step, pinned to the same `actions/checkout` commit the other workflows use:

```yaml
     steps:
+      - name: Checkout project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Check for long lines
```

A wider pattern for the whole-Mathlib import check. Since #197 the module system carries import modifiers, so the bare form the pattern anchors on is no longer the only way to write it:

```diff
-'^import Mathlib$'
+'^(public |private |protected |meta )*import (all )?Mathlib$'
```

| Line | Old pattern | New pattern |
|---|---|---|
| `import Mathlib` | flagged | flagged |
| `public import Mathlib` | missed | flagged |
| `import all Mathlib` | missed | flagged |
| `meta import Mathlib` | missed | flagged |
| `public import Mathlib.AlgebraicTopology.Quasicategory.Basic` | clean | clean |

## What this does not do

The workflow is currently disabled in the repository's Actions settings and has no recorded runs. This change leaves that alone, because the long-line check does not pass on `main` as it stands. Run against the tree at 8c1b085 it reports 36 lines over 100 columns:

| File | Lines over 100 columns |
|---|---|
| ForMathlib/CategoryTheory/Enriched/MonoidalProdCat.lean | 8 |
| ForMathlib/CategoryTheory/Enriched/Tensors.lean | 7 |
| ForMathlib/AlgebraicTopology/Quasicategory/TwoTruncated.lean | 7 |
| ForMathlib/CategoryTheory/Enriched/Cotensors.lean | 6 |
| ForMathlib/InfinityCosmos/Goals.lean | 3 |
| ForMathlib/AlgebraicTopology/SimplicialSet/CoherentIso.lean | 3 |
| ForMathlib/AlgebraicTopology/SimplicialSet/Homotopy.lean | 1 |
| ForMathlib/AlgebraicTopology/SimplicialCategory/Cotensors.lean | 1 |

Most sit in docstrings and comments rather than in proofs.

Chosen: fix the workflow and report the count, so the checks are correct whenever the maintainers decide to switch the workflow back on. Alternative: reflow the 36 lines in the same pull request, rejected because it mixes a CI fix with edits to eight source files and would need review from the authors of each.

## Checks run

Both patterns were run against the full tree at 8c1b085. The import check passes: no file imports Mathlib in any of the four forms. The long-line check reports the 36 lines tabulated above. `lake build` on that tree completes 1371 jobs with the `v4.32.2` toolchain, so the 36 lines are a formatting matter and nothing more.
