### PR TITLE
chore: drop the superseded update_mathlib.sh

### DIFF
--- a/scripts/update_mathlib.sh
+++ b/scripts/update_mathlib.sh
@@ -1,8 +1,0 @@
-# Update Mathlib and the Lean toolchain.
-
-# Download the latest lean-toolchain file from the Mathlib4 repository
-curl -L https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain -o lean-toolchain
-
-# Update the Mathlib dependencies and ensure doc-gen is also updated
-# The `-R -Kenv=dev` flag ensures that the development environment is updated, including doc-gen
-lake -R -Kenv=dev update


### PR DESCRIPTION
`scripts/update_mathlib.sh` predates the `downstream-reports` machinery in `update.yml` and now contradicts it. Following the script leaves a working copy that the pinned build cannot reproduce.

```bash
curl -L https://raw.githubusercontent.com/leanprover-community/mathlib4/master/lean-toolchain -o lean-toolchain
lake -R -Kenv=dev update
```

Three ways it has fallen out of step with the repository as it stands.

| Line | Problem |
|---|---|
| `curl ... master/lean-toolchain` | Overwrites `lean-toolchain` with mathlib master's copy, currently `v4.34.0-rc1`, while `lakefile.toml` pins mathlib at `905b958`, which is `v4.32.2`. The pair does not match and the build fails before it starts. |
| `lake -R -Kenv=dev update` | `lakefile.toml` defines no `dev` environment. doc-gen is not a dependency of this project and is supplied by `docgen-action` in `blueprint.yml`. |
| `lake update` at all | It rewrites `lake-manifest.json` and moves `checkdecls`, which carries no `rev`, off whatever the manifest locked. |

The daily `Update Dependencies` workflow does this job instead, through `bump-to-latest` and `open-bump-pr`, and it also records a last-known-good commit and reports incompatibilities. Nine bumps have landed that way since June, most recently #200.

Chosen: delete the script, leaving one bumping mechanism in the repository. Alternative: rewrite it as a local mirror of `update.yml`, rejected because the workflow's value is in the last-known-good tracking it keeps against mathlib master, which a local script cannot reproduce, and a second mechanism would diverge from the workflow the first time either one changed.

## Checks run

`git grep update_mathlib` matches nothing outside the file itself, so no workflow, README, or contributing document points at it. `scripts/` held no other file and goes with it. `lake build` on the tree with the script removed completes 1371 jobs on the `v4.32.2` toolchain.
