### PR TITLE
docs(contributing): document the local build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,23 @@
 Thank you for your interest in contributing to the InfinityCosmos Project!
 This guide provides detailed instructions on how to effectively and efficiently contribute to the project.
 
+## Building the Project Locally
+
+[elan](https://github.com/leanprover/elan) is the only prerequisite. It reads `lean-toolchain` and installs the Lean version named there on the first `lake` command; no separate Lean install is needed.
+
+```bash
+git clone https://github.com/emilyriehl/infinity-cosmos.git
+cd infinity-cosmos
+lake exe cache get   # download Mathlib's prebuilt files
+lake build
+```
+
+Without `lake exe cache get`, `lake build` compiles Mathlib from source, which takes hours. Run it again after any change to `lake-manifest.json`, including a dependency bump pulled from `main`.
+
+`lake build :blueprint` builds the blueprint declarations as well. The `Compile blueprint` workflow runs that target on every pull request.
+
+A first build takes a few minutes and needs about 10 GB: 2.8 GB for the toolchain under `~/.elan`, and 7.6 GB for dependencies and build output under `.lake`.
+
 ## Project Coordination
 
 The project is managed using a [GitHub project dashboard](https://github.com/users/emilyriehl/projects/2),


### PR DESCRIPTION
Nothing in the repository says how to build it. The README is a row of badges and this guide covers the dashboard workflow from claiming an issue to merging a pull request, so a newcomer who clones the project and runs `lake build` compiles Mathlib from source and waits hours for what `lake exe cache get` fetches in minutes.

This adds a section to CONTRIBUTING.md ahead of Project Coordination:

```bash
git clone https://github.com/emilyriehl/infinity-cosmos.git
cd infinity-cosmos
lake exe cache get   # download Mathlib's prebuilt files
lake build
```

The surrounding text states that elan is the only prerequisite and installs the Lean version named in `lean-toolchain`, that `cache get` wants rerunning whenever `lake-manifest.json` moves, that `lake build :blueprint` is the target `Compile blueprint` runs, and that the whole thing needs about 10 GB.

## Measured on a clone at 8c1b085

| Step | Result |
|---|---|
| First `lake` command | elan fetches `v4.32.2` from `lean-toolchain` with no separate install |
| `lake exe cache get` then `lake build` | 1371 jobs, under four minutes end to end |
| `lake build :blueprint` | 1425 jobs |
| `~/.elan` toolchain | 2.8 GB |
| `.lake` dependencies and build output | 7.6 GB |

Almost all of that time goes on pulling roughly 7 GB of prebuilt Mathlib files, so it tracks bandwidth. The section says a few minutes rather than quoting a figure from one machine.

Chosen: put this in CONTRIBUTING.md, where someone about to submit a pull request is already reading. Alternative: put it in the README, rejected because the README is a badge row pointing at the website, the blueprint and the docs, and a build recipe belongs a level below the links a visitor wants first.

## Checks run

Every command in the section was run in order on a clone reset to 8c1b085, with no toolchain installed for that version beforehand. `lake build` reports 1371 jobs and `lake build :blueprint` reports 1425, both exit 0. The disk figures come from `du -sh` on the two directories after that build.
