### PR TITLE
Add Alejandro José Soto Franco to contributors list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,7 @@ Once you are assigned to an issue, begin working on the corresponding task. You 
 * [Emily Riehl](https://github.com/emilyriehl)
 * [Joël Riou](https://github.com/joelriou)
 * [Robert Sneiderman](https://github.com/Robby955)
+* [Alejandro José Soto Franco](https://github.com/alejandro-soto-franco)
 * [Joseph Tooby-Smith](https://github.com/jstoobysmith)
 * [Adam Topaz](https://github.com/adamtopaz)
 * [Dominic Verity](https://github.com/dom-verity)


### PR DESCRIPTION
Adds me to the contributors list, as invited in #204.

Placed alphabetically by surname, between Sneiderman and Tooby-Smith, which is how the rest of the list is ordered.
