### PR TITLE
chore(ci): bump docgen-action

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -66,7 +66,7 @@ jobs:
           build-args: :blueprint
 
       - name: Compile blueprint and documentation
-        uses: leanprover-community/docgen-action@cc833d262c7b8f179ac444cd20fde412b24b8beb # 2026-01-08
+        uses: leanprover-community/docgen-action@10db47458f91456d87804787d3dfcd914b9a19e3 # 2026-06-07
         with:
           blueprint: true
           homepage: home_page

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
     - name: lean-release-tag action
-      uses: leanprover-community/lean-release-tag@ee8ee743e5a36ff0e75ff51035f6a95a9d1bdf59 # 2025-05-22
+      uses: leanprover-community/lean-release-tag@ee8ee743e5a36ff0e75ff51035f6a95a9d1bdf59 # 2026-02-27
       with:
         before: ${{ github.event.before }}
         after: ${{ github.event.after }}


### PR DESCRIPTION
The `Compile blueprint` run on `a0aad97` failed in the docs step:

```
error: no such file or directory (error code: 4294967294)
  file: .../docbuild/.lake/build/doc/style.css
```
leanprover-community/docgen-action#29, "fix: add static files to the list of files to cache" fixes this. It merged on 2026-04-14. The pin here dated from 2026-01-08.